### PR TITLE
Migrate tokenV2 models and their dependencies (some of token)

### DIFF
--- a/processor/src/db/models/mod.rs
+++ b/processor/src/db/models/mod.rs
@@ -7,3 +7,6 @@ pub mod stake_models;
 pub mod token_models;
 pub mod token_v2_models;
 pub mod user_transactions_models_temp;
+
+// Default None value for parquet fields that are not set
+const DEFAULT_NONE: &str = "NULL";

--- a/processor/src/db/models/token_models/collection_datas.rs
+++ b/processor/src/db/models/token_models/collection_datas.rs
@@ -1,0 +1,208 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+#![allow(clippy::unused_unit)]
+
+use super::{
+    token_utils::{CollectionDataIdType, TokenWriteSet},
+    tokens::TableHandleToOwner,
+};
+use crate::{
+    schema::{collection_datas, current_collection_datas},
+    utils::{database::DbPoolConnection, util::standardize_address},
+};
+use aptos_protos::transaction::v1::WriteTableItem;
+use bigdecimal::BigDecimal;
+use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
+use field_count::FieldCount;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(collection_data_id_hash, transaction_version))]
+#[diesel(table_name = collection_datas)]
+pub struct CollectionData {
+    pub collection_data_id_hash: String,
+    pub transaction_version: i64,
+    pub creator_address: String,
+    pub collection_name: String,
+    pub description: String,
+    pub metadata_uri: String,
+    pub supply: BigDecimal,
+    pub maximum: BigDecimal,
+    pub maximum_mutable: bool,
+    pub uri_mutable: bool,
+    pub description_mutable: bool,
+    pub table_handle: String,
+    pub transaction_timestamp: chrono::NaiveDateTime,
+}
+
+#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(collection_data_id_hash))]
+#[diesel(table_name = current_collection_datas)]
+pub struct CurrentCollectionData {
+    pub collection_data_id_hash: String,
+    pub creator_address: String,
+    pub collection_name: String,
+    pub description: String,
+    pub metadata_uri: String,
+    pub supply: BigDecimal,
+    pub maximum: BigDecimal,
+    pub maximum_mutable: bool,
+    pub uri_mutable: bool,
+    pub description_mutable: bool,
+    pub last_transaction_version: i64,
+    pub table_handle: String,
+    pub last_transaction_timestamp: chrono::NaiveDateTime,
+}
+
+/// Need a separate struct for queryable because we don't want to define the inserted_at column (letting DB fill)
+#[derive(Debug, Identifiable, Queryable)]
+#[diesel(primary_key(collection_data_id_hash))]
+#[diesel(table_name = current_collection_datas)]
+pub struct CurrentCollectionDataQuery {
+    pub collection_data_id_hash: String,
+    pub creator_address: String,
+    pub collection_name: String,
+    pub description: String,
+    pub metadata_uri: String,
+    pub supply: BigDecimal,
+    pub maximum: BigDecimal,
+    pub maximum_mutable: bool,
+    pub uri_mutable: bool,
+    pub description_mutable: bool,
+    pub last_transaction_version: i64,
+    pub inserted_at: chrono::NaiveDateTime,
+    pub table_handle: String,
+    pub last_transaction_timestamp: chrono::NaiveDateTime,
+}
+
+impl CollectionData {
+    pub async fn from_write_table_item(
+        table_item: &WriteTableItem,
+        txn_version: i64,
+        txn_timestamp: chrono::NaiveDateTime,
+        table_handle_to_owner: &TableHandleToOwner,
+        conn: &mut DbPoolConnection<'_>,
+        query_retries: u32,
+        query_retry_delay_ms: u64,
+    ) -> anyhow::Result<Option<(Self, CurrentCollectionData)>> {
+        let table_item_data = table_item.data.as_ref().unwrap();
+
+        let maybe_collection_data = match TokenWriteSet::from_table_item_type(
+            table_item_data.value_type.as_str(),
+            &table_item_data.value,
+            txn_version,
+        )? {
+            Some(TokenWriteSet::CollectionData(inner)) => Some(inner),
+            _ => None,
+        };
+        if let Some(collection_data) = maybe_collection_data {
+            let table_handle = table_item.handle.to_string();
+            let maybe_creator_address = table_handle_to_owner
+                .get(&standardize_address(&table_handle))
+                .map(|table_metadata| table_metadata.get_owner_address());
+            let mut creator_address = match maybe_creator_address {
+                Some(ca) => ca,
+                None => match Self::get_collection_creator(
+                    conn,
+                    &table_handle,
+                    query_retries,
+                    query_retry_delay_ms,
+                )
+                .await
+                {
+                    Ok(creator) => creator,
+                    Err(_) => {
+                        tracing::error!(
+                            transaction_version = txn_version,
+                            lookup_key = &table_handle,
+                            "Failed to get collection creator for table handle. You probably should backfill db."
+                        );
+                        return Ok(None);
+                    },
+                },
+            };
+            creator_address = standardize_address(&creator_address);
+            let collection_data_id =
+                CollectionDataIdType::new(creator_address, collection_data.get_name().to_string());
+            let collection_data_id_hash = collection_data_id.to_hash();
+            let collection_name = collection_data.get_name_trunc();
+            let metadata_uri = collection_data.get_uri_trunc();
+
+            Ok(Some((
+                Self {
+                    collection_data_id_hash: collection_data_id_hash.clone(),
+                    collection_name: collection_name.clone(),
+                    creator_address: collection_data_id.creator.clone(),
+                    description: collection_data.description.clone(),
+                    transaction_version: txn_version,
+                    metadata_uri: metadata_uri.clone(),
+                    supply: collection_data.supply.clone(),
+                    maximum: collection_data.maximum.clone(),
+                    maximum_mutable: collection_data.mutability_config.maximum,
+                    uri_mutable: collection_data.mutability_config.uri,
+                    description_mutable: collection_data.mutability_config.description,
+                    table_handle: table_handle.clone(),
+                    transaction_timestamp: txn_timestamp,
+                },
+                CurrentCollectionData {
+                    collection_data_id_hash,
+                    collection_name,
+                    creator_address: collection_data_id.creator,
+                    description: collection_data.description,
+                    metadata_uri,
+                    supply: collection_data.supply,
+                    maximum: collection_data.maximum,
+                    maximum_mutable: collection_data.mutability_config.maximum,
+                    uri_mutable: collection_data.mutability_config.uri,
+                    description_mutable: collection_data.mutability_config.description,
+                    last_transaction_version: txn_version,
+                    table_handle,
+                    last_transaction_timestamp: txn_timestamp,
+                },
+            )))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// If collection data is not in resources of the same transaction, then try looking for it in the database. Since collection owner
+    /// cannot change, we can just look in the current_collection_datas table.
+    /// Retrying a few times since this collection could've been written in a separate thread.
+    pub async fn get_collection_creator(
+        conn: &mut DbPoolConnection<'_>,
+        table_handle: &str,
+        query_retries: u32,
+        query_retry_delay_ms: u64,
+    ) -> anyhow::Result<String> {
+        let mut tried = 0;
+        while tried < query_retries {
+            tried += 1;
+            match CurrentCollectionDataQuery::get_by_table_handle(conn, table_handle).await {
+                Ok(current_collection_data) => return Ok(current_collection_data.creator_address),
+                Err(_) => {
+                    if tried < query_retries {
+                        tokio::time::sleep(std::time::Duration::from_millis(query_retry_delay_ms))
+                            .await;
+                    }
+                },
+            }
+        }
+        Err(anyhow::anyhow!("Failed to get collection creator"))
+    }
+}
+
+impl CurrentCollectionDataQuery {
+    pub async fn get_by_table_handle(
+        conn: &mut DbPoolConnection<'_>,
+        table_handle: &str,
+    ) -> diesel::QueryResult<Self> {
+        current_collection_datas::table
+            .filter(current_collection_datas::table_handle.eq(table_handle))
+            .first::<Self>(conn)
+            .await
+    }
+}

--- a/processor/src/db/models/token_models/mod.rs
+++ b/processor/src/db/models/token_models/mod.rs
@@ -1,4 +1,8 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod collection_datas;
+pub mod token_datas;
+pub mod token_ownerships;
 pub mod token_utils;
+pub mod tokens;

--- a/processor/src/db/models/token_models/token_datas.rs
+++ b/processor/src/db/models/token_models/token_datas.rs
@@ -1,0 +1,167 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+#![allow(clippy::unused_unit)]
+
+use super::token_utils::TokenWriteSet;
+use crate::schema::{current_token_datas, token_datas};
+use aptos_protos::transaction::v1::WriteTableItem;
+use bigdecimal::BigDecimal;
+use field_count::FieldCount;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(token_data_id_hash, transaction_version))]
+#[diesel(table_name = token_datas)]
+pub struct TokenData {
+    pub token_data_id_hash: String,
+    pub transaction_version: i64,
+    pub creator_address: String,
+    pub collection_name: String,
+    pub name: String,
+    pub maximum: BigDecimal,
+    pub supply: BigDecimal,
+    pub largest_property_version: BigDecimal,
+    pub metadata_uri: String,
+    pub payee_address: String,
+    pub royalty_points_numerator: BigDecimal,
+    pub royalty_points_denominator: BigDecimal,
+    pub maximum_mutable: bool,
+    pub uri_mutable: bool,
+    pub description_mutable: bool,
+    pub properties_mutable: bool,
+    pub royalty_mutable: bool,
+    pub default_properties: serde_json::Value,
+    pub collection_data_id_hash: String,
+    pub transaction_timestamp: chrono::NaiveDateTime,
+    pub description: String,
+}
+
+#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(token_data_id_hash))]
+#[diesel(table_name = current_token_datas)]
+pub struct CurrentTokenData {
+    pub token_data_id_hash: String,
+    pub creator_address: String,
+    pub collection_name: String,
+    pub name: String,
+    pub maximum: bigdecimal::BigDecimal,
+    pub supply: bigdecimal::BigDecimal,
+    pub largest_property_version: bigdecimal::BigDecimal,
+    pub metadata_uri: String,
+    pub payee_address: String,
+    pub royalty_points_numerator: bigdecimal::BigDecimal,
+    pub royalty_points_denominator: bigdecimal::BigDecimal,
+    pub maximum_mutable: bool,
+    pub uri_mutable: bool,
+    pub description_mutable: bool,
+    pub properties_mutable: bool,
+    pub royalty_mutable: bool,
+    pub default_properties: serde_json::Value,
+    pub last_transaction_version: i64,
+    pub collection_data_id_hash: String,
+    pub last_transaction_timestamp: chrono::NaiveDateTime,
+    pub description: String,
+}
+
+impl TokenData {
+    pub fn from_write_table_item(
+        table_item: &WriteTableItem,
+        txn_version: i64,
+        txn_timestamp: chrono::NaiveDateTime,
+    ) -> anyhow::Result<Option<(Self, CurrentTokenData)>> {
+        let table_item_data = table_item.data.as_ref().unwrap();
+
+        let maybe_token_data = match TokenWriteSet::from_table_item_type(
+            table_item_data.value_type.as_str(),
+            &table_item_data.value,
+            txn_version,
+        )? {
+            Some(TokenWriteSet::TokenData(inner)) => Some(inner),
+            _ => None,
+        };
+
+        if let Some(token_data) = maybe_token_data {
+            let maybe_token_data_id = match TokenWriteSet::from_table_item_type(
+                table_item_data.key_type.as_str(),
+                &table_item_data.key,
+                txn_version,
+            )? {
+                Some(TokenWriteSet::TokenDataId(inner)) => Some(inner),
+                _ => None,
+            };
+            if let Some(token_data_id) = maybe_token_data_id {
+                let collection_data_id_hash = token_data_id.get_collection_data_id_hash();
+                let token_data_id_hash = token_data_id.to_hash();
+                let collection_name = token_data_id.get_collection_trunc();
+                let name = token_data_id.get_name_trunc();
+                let metadata_uri = token_data.get_uri_trunc();
+
+                return Ok(Some((
+                    Self {
+                        collection_data_id_hash: collection_data_id_hash.clone(),
+                        token_data_id_hash: token_data_id_hash.clone(),
+                        creator_address: token_data_id.get_creator_address(),
+                        collection_name: collection_name.clone(),
+                        name: name.clone(),
+                        transaction_version: txn_version,
+                        maximum: token_data.maximum.clone(),
+                        supply: token_data.supply.clone(),
+                        largest_property_version: token_data.largest_property_version.clone(),
+                        metadata_uri: metadata_uri.clone(),
+                        payee_address: token_data.royalty.get_payee_address(),
+                        royalty_points_numerator: token_data
+                            .royalty
+                            .royalty_points_numerator
+                            .clone(),
+                        royalty_points_denominator: token_data
+                            .royalty
+                            .royalty_points_denominator
+                            .clone(),
+                        maximum_mutable: token_data.mutability_config.maximum,
+                        uri_mutable: token_data.mutability_config.uri,
+                        description_mutable: token_data.mutability_config.description,
+                        properties_mutable: token_data.mutability_config.properties,
+                        royalty_mutable: token_data.mutability_config.royalty,
+                        default_properties: token_data.default_properties.clone(),
+                        transaction_timestamp: txn_timestamp,
+                        description: token_data.description.clone(),
+                    },
+                    CurrentTokenData {
+                        collection_data_id_hash,
+                        token_data_id_hash,
+                        creator_address: token_data_id.get_creator_address(),
+                        collection_name,
+                        name,
+                        maximum: token_data.maximum,
+                        supply: token_data.supply,
+                        largest_property_version: token_data.largest_property_version,
+                        metadata_uri,
+                        payee_address: token_data.royalty.get_payee_address(),
+                        royalty_points_numerator: token_data.royalty.royalty_points_numerator,
+                        royalty_points_denominator: token_data.royalty.royalty_points_denominator,
+                        maximum_mutable: token_data.mutability_config.maximum,
+                        uri_mutable: token_data.mutability_config.uri,
+                        description_mutable: token_data.mutability_config.description,
+                        properties_mutable: token_data.mutability_config.properties,
+                        royalty_mutable: token_data.mutability_config.royalty,
+                        default_properties: token_data.default_properties,
+                        last_transaction_version: txn_version,
+                        last_transaction_timestamp: txn_timestamp,
+                        description: token_data.description,
+                    },
+                )));
+            } else {
+                tracing::warn!(
+                    transaction_version = txn_version,
+                    key_type = table_item_data.key_type,
+                    key = table_item_data.key,
+                    "Expecting token_data_id as key for value = token_data"
+                );
+            }
+        }
+        Ok(None)
+    }
+}

--- a/processor/src/db/models/token_models/token_ownerships.rs
+++ b/processor/src/db/models/token_models/token_ownerships.rs
@@ -1,0 +1,134 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+#![allow(clippy::unused_unit)]
+
+use super::{
+    token_utils::TokenWriteSet,
+    tokens::{TableHandleToOwner, Token},
+};
+use crate::{
+    schema::{current_token_ownerships, token_ownerships},
+    utils::util::standardize_address,
+};
+use bigdecimal::BigDecimal;
+use field_count::FieldCount;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(
+    token_data_id_hash,
+    property_version,
+    transaction_version,
+    table_handle
+))]
+#[diesel(table_name = token_ownerships)]
+pub struct TokenOwnership {
+    pub token_data_id_hash: String,
+    pub property_version: BigDecimal,
+    pub transaction_version: i64,
+    pub table_handle: String,
+    pub creator_address: String,
+    pub collection_name: String,
+    pub name: String,
+    pub owner_address: Option<String>,
+    pub amount: BigDecimal,
+    pub table_type: Option<String>,
+    pub collection_data_id_hash: String,
+    pub transaction_timestamp: chrono::NaiveDateTime,
+}
+
+#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(token_data_id_hash, property_version, owner_address))]
+#[diesel(table_name = current_token_ownerships)]
+pub struct CurrentTokenOwnership {
+    pub token_data_id_hash: String,
+    pub property_version: BigDecimal,
+    pub owner_address: String,
+    pub creator_address: String,
+    pub collection_name: String,
+    pub name: String,
+    pub amount: BigDecimal,
+    pub token_properties: serde_json::Value,
+    pub last_transaction_version: i64,
+    pub collection_data_id_hash: String,
+    pub table_type: String,
+    pub last_transaction_timestamp: chrono::NaiveDateTime,
+}
+
+impl TokenOwnership {
+    /// We only want to track tokens in 0x1::token::TokenStore for now. This is because the table
+    /// schema doesn't have table type (i.e. token container) as primary key. TokenStore has token_id
+    /// as key and token as value.
+    pub fn from_token(
+        token: &Token,
+        table_item_key_type: &str,
+        table_item_key: &str,
+        amount: BigDecimal,
+        table_handle: String,
+        table_handle_to_owner: &TableHandleToOwner,
+    ) -> anyhow::Result<Option<(Self, Option<CurrentTokenOwnership>)>> {
+        let txn_version = token.transaction_version;
+        let maybe_token_id = match TokenWriteSet::from_table_item_type(
+            table_item_key_type,
+            table_item_key,
+            txn_version,
+        )? {
+            Some(TokenWriteSet::TokenId(inner)) => Some(inner),
+            _ => None,
+        };
+        // Return early if table key is not token id
+        if maybe_token_id.is_none() {
+            return Ok(None);
+        }
+        let table_handle = standardize_address(&table_handle);
+        let maybe_table_metadata = table_handle_to_owner.get(&table_handle);
+        // Return early if table type is not tokenstore
+        if let Some(tm) = maybe_table_metadata {
+            if tm.table_type != "0x3::token::TokenStore" {
+                return Ok(None);
+            }
+        }
+        let (curr_token_ownership, owner_address, table_type) = match maybe_table_metadata {
+            Some(tm) => (
+                Some(CurrentTokenOwnership {
+                    collection_data_id_hash: token.collection_data_id_hash.clone(),
+                    token_data_id_hash: token.token_data_id_hash.clone(),
+                    property_version: token.property_version.clone(),
+                    owner_address: tm.get_owner_address(),
+                    creator_address: standardize_address(&token.creator_address.clone()),
+                    collection_name: token.collection_name.clone(),
+                    name: token.name.clone(),
+                    amount: amount.clone(),
+                    token_properties: token.token_properties.clone(),
+                    last_transaction_version: txn_version,
+                    table_type: tm.table_type.clone(),
+                    last_transaction_timestamp: token.transaction_timestamp,
+                }),
+                Some(tm.get_owner_address()),
+                Some(tm.table_type.clone()),
+            ),
+            None => (None, None, None),
+        };
+
+        Ok(Some((
+            Self {
+                collection_data_id_hash: token.collection_data_id_hash.clone(),
+                token_data_id_hash: token.token_data_id_hash.clone(),
+                property_version: token.property_version.clone(),
+                owner_address: owner_address.map(|s| standardize_address(&s)),
+                creator_address: standardize_address(&token.creator_address),
+                collection_name: token.collection_name.clone(),
+                name: token.name.clone(),
+                amount,
+                table_type,
+                transaction_version: token.transaction_version,
+                table_handle,
+                transaction_timestamp: token.transaction_timestamp,
+            },
+            curr_token_ownership,
+        )))
+    }
+}

--- a/processor/src/db/models/token_models/tokens.rs
+++ b/processor/src/db/models/token_models/tokens.rs
@@ -1,0 +1,417 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+#![allow(clippy::unused_unit)]
+
+use super::{
+    collection_datas::{CollectionData, CurrentCollectionData},
+    token_datas::{CurrentTokenData, TokenData},
+    token_ownerships::{CurrentTokenOwnership, TokenOwnership},
+    token_utils::{TokenResource, TokenWriteSet},
+};
+use crate::{
+    // TODO: update this to use the new move resources after refactoring
+    db::models::old_default_models::postgres_move_resources::MoveResource,
+    schema::tokens,
+    utils::{
+        counters::PROCESSOR_UNKNOWN_TYPE_COUNT,
+        database::DbPoolConnection,
+        util::{ensure_not_negative, parse_timestamp, standardize_address},
+    },
+};
+use ahash::AHashMap;
+use aptos_protos::transaction::v1::{
+    transaction::TxnData, write_set_change::Change as WriteSetChangeEnum, DeleteTableItem,
+    Transaction, WriteResource, WriteTableItem,
+};
+use bigdecimal::{BigDecimal, Zero};
+use field_count::FieldCount;
+use serde::{Deserialize, Serialize};
+
+type TableHandle = String;
+type Address = String;
+type TableType = String;
+pub type TableHandleToOwner = AHashMap<TableHandle, TableMetadataForToken>;
+pub type TokenDataIdHash = String;
+// PK of current_token_ownerships, i.e. token_data_id_hash + property_version + owner_address, used to dedupe
+pub type CurrentTokenOwnershipPK = (TokenDataIdHash, BigDecimal, Address);
+// PK of current_token_pending_claims, i.e. token_data_id_hash + property_version + to/from_address, used to dedupe
+pub type CurrentTokenPendingClaimPK = (TokenDataIdHash, BigDecimal, Address, Address);
+// PK of tokens table, used to dedupe tokens
+pub type TokenPK = (TokenDataIdHash, BigDecimal);
+
+#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(token_data_id_hash, property_version, transaction_version))]
+#[diesel(table_name = tokens)]
+pub struct Token {
+    pub token_data_id_hash: String,
+    pub property_version: BigDecimal,
+    pub transaction_version: i64,
+    pub creator_address: String,
+    pub collection_name: String,
+    pub name: String,
+    pub token_properties: serde_json::Value,
+    pub collection_data_id_hash: String,
+    pub transaction_timestamp: chrono::NaiveDateTime,
+}
+
+#[derive(Debug)]
+pub struct TableMetadataForToken {
+    owner_address: Address,
+    pub table_type: TableType,
+}
+
+impl Token {
+    /// We can find token data from write sets in user transactions. Table items will contain metadata for collections
+    /// and tokens. To find ownership, we have to look in write resource write sets for who owns those table handles
+    ///
+    /// We also will compute current versions of the token tables which are at a higher granularity than the transactional tables (only
+    /// state at the last transaction will be tracked, hence using hashmap to dedupe)
+    pub async fn from_transaction(
+        transaction: &Transaction,
+        table_handle_to_owner: &TableHandleToOwner,
+        conn: &mut DbPoolConnection<'_>,
+        query_retries: u32,
+        query_retry_delay_ms: u64,
+    ) -> (
+        Vec<Self>,
+        Vec<TokenOwnership>,
+        Vec<TokenData>,
+        Vec<CollectionData>,
+        AHashMap<CurrentTokenOwnershipPK, CurrentTokenOwnership>,
+        AHashMap<TokenDataIdHash, CurrentTokenData>,
+        AHashMap<TokenDataIdHash, CurrentCollectionData>,
+    ) {
+        let txn_data = match transaction.txn_data.as_ref() {
+            Some(data) => data,
+            None => {
+                PROCESSOR_UNKNOWN_TYPE_COUNT
+                    .with_label_values(&["Token"])
+                    .inc();
+                tracing::warn!(
+                    transaction_version = transaction.version,
+                    "Transaction data doesn't exist",
+                );
+                return (
+                    vec![],
+                    vec![],
+                    vec![],
+                    vec![],
+                    AHashMap::new(),
+                    AHashMap::new(),
+                    AHashMap::new(),
+                );
+            },
+        };
+        if let TxnData::User(_) = txn_data {
+            let mut token_ownerships = vec![];
+            let mut token_datas = vec![];
+            let mut collection_datas = vec![];
+
+            let mut tokens: AHashMap<TokenPK, Token> = AHashMap::new();
+            let mut current_token_ownerships: AHashMap<
+                CurrentTokenOwnershipPK,
+                CurrentTokenOwnership,
+            > = AHashMap::new();
+            let mut current_token_datas: AHashMap<TokenDataIdHash, CurrentTokenData> =
+                AHashMap::new();
+            let mut current_collection_datas: AHashMap<TokenDataIdHash, CurrentCollectionData> =
+                AHashMap::new();
+
+            let txn_version = transaction.version as i64;
+            let txn_timestamp =
+                parse_timestamp(transaction.timestamp.as_ref().unwrap(), txn_version);
+            let transaction_info = transaction
+                .info
+                .as_ref()
+                .expect("Transaction info doesn't exist!");
+
+            for wsc in &transaction_info.changes {
+                // Basic token and ownership data
+                let (maybe_token_w_ownership, maybe_token_data, maybe_collection_data) =
+                    match wsc.change.as_ref().unwrap() {
+                        WriteSetChangeEnum::WriteTableItem(write_table_item) => (
+                            Self::from_write_table_item(
+                                write_table_item,
+                                txn_version,
+                                txn_timestamp,
+                                table_handle_to_owner,
+                            )
+                            .unwrap(),
+                            TokenData::from_write_table_item(
+                                write_table_item,
+                                txn_version,
+                                txn_timestamp,
+                            )
+                            .unwrap(),
+                            CollectionData::from_write_table_item(
+                                write_table_item,
+                                txn_version,
+                                txn_timestamp,
+                                table_handle_to_owner,
+                                conn,
+                                query_retries,
+                                query_retry_delay_ms,
+                            )
+                            .await
+                            .unwrap(),
+                        ),
+                        WriteSetChangeEnum::DeleteTableItem(delete_table_item) => (
+                            Self::from_delete_table_item(
+                                delete_table_item,
+                                txn_version,
+                                txn_timestamp,
+                                table_handle_to_owner,
+                            )
+                            .unwrap(),
+                            None,
+                            None,
+                        ),
+                        _ => (None, None, None),
+                    };
+
+                if let Some((token, maybe_token_ownership, maybe_current_token_ownership)) =
+                    maybe_token_w_ownership
+                {
+                    tokens.insert(
+                        (
+                            token.token_data_id_hash.clone(),
+                            token.property_version.clone(),
+                        ),
+                        token,
+                    );
+                    if let Some(token_ownership) = maybe_token_ownership {
+                        token_ownerships.push(token_ownership);
+                    }
+                    if let Some(current_token_ownership) = maybe_current_token_ownership {
+                        current_token_ownerships.insert(
+                            (
+                                current_token_ownership.token_data_id_hash.clone(),
+                                current_token_ownership.property_version.clone(),
+                                current_token_ownership.owner_address.clone(),
+                            ),
+                            current_token_ownership,
+                        );
+                    }
+                }
+                if let Some((token_data, current_token_data)) = maybe_token_data {
+                    token_datas.push(token_data);
+                    current_token_datas.insert(
+                        current_token_data.token_data_id_hash.clone(),
+                        current_token_data,
+                    );
+                }
+                if let Some((collection_data, current_collection_data)) = maybe_collection_data {
+                    collection_datas.push(collection_data);
+                    current_collection_datas.insert(
+                        current_collection_data.collection_data_id_hash.clone(),
+                        current_collection_data,
+                    );
+                }
+            }
+            return (
+                tokens.into_values().collect(),
+                token_ownerships,
+                token_datas,
+                collection_datas,
+                current_token_ownerships,
+                current_token_datas,
+                current_collection_datas,
+            );
+        }
+        Default::default()
+    }
+
+    /// Get token from write table item. Table items don't have address of the table so we need to look it up in the table_handle_to_owner mapping
+    /// We get the mapping from resource.
+    /// If the mapping is missing we'll just leave owner address as blank. This isn't great but at least helps us account for the token
+    pub fn from_write_table_item(
+        table_item: &WriteTableItem,
+        txn_version: i64,
+        txn_timestamp: chrono::NaiveDateTime,
+        table_handle_to_owner: &TableHandleToOwner,
+    ) -> anyhow::Result<Option<(Self, Option<TokenOwnership>, Option<CurrentTokenOwnership>)>> {
+        let table_item_data = table_item.data.as_ref().unwrap();
+
+        let maybe_token = match TokenWriteSet::from_table_item_type(
+            table_item_data.value_type.as_str(),
+            &table_item_data.value,
+            txn_version,
+        )? {
+            Some(TokenWriteSet::Token(inner)) => Some(inner),
+            _ => None,
+        };
+
+        if let Some(token) = maybe_token {
+            let token_id = token.id;
+            let token_data_id = token_id.token_data_id;
+            let collection_data_id_hash = token_data_id.get_collection_data_id_hash();
+            let token_data_id_hash = token_data_id.to_hash();
+            let collection_name = token_data_id.get_collection_trunc();
+            let name = token_data_id.get_name_trunc();
+
+            let token_pg = Self {
+                collection_data_id_hash,
+                token_data_id_hash,
+                creator_address: token_data_id.get_creator_address(),
+                collection_name,
+                name,
+                property_version: token_id.property_version,
+                transaction_version: txn_version,
+                token_properties: token.token_properties,
+                transaction_timestamp: txn_timestamp,
+            };
+
+            let (token_ownership, current_token_ownership) = TokenOwnership::from_token(
+                &token_pg,
+                table_item_data.key_type.as_str(),
+                &table_item_data.key,
+                ensure_not_negative(token.amount),
+                table_item.handle.to_string(),
+                table_handle_to_owner,
+            )?
+            .map(|(token_ownership, current_token_ownership)| {
+                (Some(token_ownership), current_token_ownership)
+            })
+            .unwrap_or((None, None));
+
+            Ok(Some((token_pg, token_ownership, current_token_ownership)))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Get token from delete table item. The difference from write table item is that value isn't there so
+    /// we'll set amount to 0 and token property to blank.
+    pub fn from_delete_table_item(
+        table_item: &DeleteTableItem,
+        txn_version: i64,
+        txn_timestamp: chrono::NaiveDateTime,
+        table_handle_to_owner: &TableHandleToOwner,
+    ) -> anyhow::Result<Option<(Self, Option<TokenOwnership>, Option<CurrentTokenOwnership>)>> {
+        let table_item_data = table_item.data.as_ref().unwrap();
+
+        let maybe_token_id = match TokenWriteSet::from_table_item_type(
+            table_item_data.key_type.as_str(),
+            &table_item_data.key,
+            txn_version,
+        )? {
+            Some(TokenWriteSet::TokenId(inner)) => Some(inner),
+            _ => None,
+        };
+
+        if let Some(token_id) = maybe_token_id {
+            let token_data_id = token_id.token_data_id;
+            let collection_data_id_hash = token_data_id.get_collection_data_id_hash();
+            let token_data_id_hash = token_data_id.to_hash();
+            let collection_name = token_data_id.get_collection_trunc();
+            let name = token_data_id.get_name_trunc();
+
+            let token = Self {
+                collection_data_id_hash,
+                token_data_id_hash,
+                creator_address: token_data_id.get_creator_address(),
+                collection_name,
+                name,
+                property_version: token_id.property_version,
+                transaction_version: txn_version,
+                token_properties: serde_json::Value::Null,
+                transaction_timestamp: txn_timestamp,
+            };
+            let (token_ownership, current_token_ownership) = TokenOwnership::from_token(
+                &token,
+                table_item_data.key_type.as_str(),
+                &table_item_data.key,
+                BigDecimal::zero(),
+                table_item.handle.to_string(),
+                table_handle_to_owner,
+            )?
+            .map(|(token_ownership, current_token_ownership)| {
+                (Some(token_ownership), current_token_ownership)
+            })
+            .unwrap_or((None, None));
+            Ok(Some((token, token_ownership, current_token_ownership)))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl TableMetadataForToken {
+    /// Mapping from table handle to owner type, including type of the table (AKA resource type)
+    /// from user transactions in a batch of transactions
+    pub fn get_table_handle_to_owner_from_transactions(
+        transactions: &[Transaction],
+    ) -> TableHandleToOwner {
+        let mut table_handle_to_owner: TableHandleToOwner = AHashMap::new();
+        // Do a first pass to get all the table metadata in the batch.
+        for transaction in transactions {
+            if let Some(TxnData::User(_)) = transaction.txn_data.as_ref() {
+                let txn_version = transaction.version as i64;
+
+                let transaction_info = transaction
+                    .info
+                    .as_ref()
+                    .expect("Transaction info doesn't exist!");
+                for wsc in &transaction_info.changes {
+                    if let WriteSetChangeEnum::WriteResource(write_resource) =
+                        wsc.change.as_ref().unwrap()
+                    {
+                        let maybe_map = TableMetadataForToken::get_table_handle_to_owner(
+                            write_resource,
+                            txn_version,
+                        )
+                        .unwrap();
+                        if let Some(map) = maybe_map {
+                            table_handle_to_owner.extend(map);
+                        }
+                    }
+                }
+            }
+        }
+        table_handle_to_owner
+    }
+
+    /// Mapping from table handle to owner type, including type of the table (AKA resource type)
+    fn get_table_handle_to_owner(
+        write_resource: &WriteResource,
+        txn_version: i64,
+    ) -> anyhow::Result<Option<TableHandleToOwner>> {
+        let type_str = MoveResource::get_outer_type_from_write_resource(write_resource);
+        if !TokenResource::is_resource_supported(type_str.as_str()) {
+            return Ok(None);
+        }
+        let resource = MoveResource::from_write_resource(
+            write_resource,
+            0, // Placeholder, this isn't used anyway
+            txn_version,
+            0, // Placeholder, this isn't used anyway
+        );
+
+        let value = TableMetadataForToken {
+            owner_address: resource.address.clone(),
+            table_type: write_resource.type_str.clone(),
+        };
+        let table_handle: TableHandle = match TokenResource::from_resource(
+            &type_str,
+            resource.data.as_ref().unwrap(),
+            txn_version,
+        )? {
+            TokenResource::CollectionResource(collection_resource) => {
+                collection_resource.collection_data.get_handle()
+            },
+            TokenResource::TokenStoreResource(inner) => inner.tokens.get_handle(),
+            TokenResource::PendingClaimsResource(inner) => inner.pending_claims.get_handle(),
+        };
+        Ok(Some(AHashMap::from([(
+            standardize_address(&table_handle),
+            value,
+        )])))
+    }
+
+    pub fn get_owner_address(&self) -> String {
+        standardize_address(&self.owner_address)
+    }
+}

--- a/processor/src/db/models/token_v2_models/mod.rs
+++ b/processor/src/db/models/token_v2_models/mod.rs
@@ -1,1 +1,7 @@
+pub mod token_claims;
+pub mod v1_token_royalty;
+pub mod v2_token_activities;
+pub mod v2_token_datas;
+pub mod v2_token_metadata;
+pub mod v2_token_ownerships;
 pub mod v2_token_utils;

--- a/processor/src/db/models/token_v2_models/token_claims.rs
+++ b/processor/src/db/models/token_v2_models/token_claims.rs
@@ -1,0 +1,344 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+#![allow(clippy::unused_unit)]
+
+use crate::{
+    bq_analytics::{GetTimeStamp, HasVersion, NamedTable},
+    db::models::{
+        token_models::{token_utils::TokenWriteSet, tokens::TableHandleToOwner},
+        token_v2_models::v2_token_activities::TokenActivityHelperV1,
+    },
+    schema::current_token_pending_claims,
+    utils::util::standardize_address,
+};
+use ahash::AHashMap;
+use allocative_derive::Allocative;
+use aptos_protos::transaction::v1::{DeleteTableItem, WriteTableItem};
+use bigdecimal::{BigDecimal, ToPrimitive, Zero};
+use field_count::FieldCount;
+use parquet_derive::ParquetRecordWriter;
+use serde::{Deserialize, Serialize};
+
+// Map to keep track of the metadata of token offers that were claimed. The key is the token data id of the offer.
+// Potentially it'd also be useful to keep track of offers that were canceled.
+pub type TokenV1Claimed = AHashMap<String, TokenActivityHelperV1>;
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CurrentTokenPendingClaim {
+    pub token_data_id_hash: String,
+    pub property_version: BigDecimal,
+    pub from_address: String,
+    pub to_address: String,
+    pub collection_data_id_hash: String,
+    pub creator_address: String,
+    pub collection_name: String,
+    pub name: String,
+    pub amount: BigDecimal,
+    pub table_handle: String,
+    pub last_transaction_version: i64,
+    pub last_transaction_timestamp: chrono::NaiveDateTime,
+    pub token_data_id: String,
+    pub collection_id: String,
+}
+
+impl Ord for CurrentTokenPendingClaim {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.token_data_id_hash
+            .cmp(&other.token_data_id_hash)
+            .then(self.property_version.cmp(&other.property_version))
+            .then(self.from_address.cmp(&other.from_address))
+            .then(self.to_address.cmp(&other.to_address))
+    }
+}
+
+impl PartialOrd for CurrentTokenPendingClaim {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl CurrentTokenPendingClaim {
+    /// Token claim is stored in a table in the offerer's account. The key is token_offer_id (token_id + to address)
+    /// and value is token (token_id + amount)
+    pub fn from_write_table_item(
+        table_item: &WriteTableItem,
+        txn_version: i64,
+        txn_timestamp: chrono::NaiveDateTime,
+        table_handle_to_owner: &TableHandleToOwner,
+    ) -> anyhow::Result<Option<Self>> {
+        let table_item_data = table_item.data.as_ref().unwrap();
+
+        let maybe_offer = match TokenWriteSet::from_table_item_type(
+            table_item_data.key_type.as_str(),
+            &table_item_data.key,
+            txn_version,
+        )? {
+            Some(TokenWriteSet::TokenOfferId(inner)) => Some(inner),
+            _ => None,
+        };
+        if let Some(offer) = &maybe_offer {
+            let maybe_token = match TokenWriteSet::from_table_item_type(
+                table_item_data.value_type.as_str(),
+                &table_item_data.value,
+                txn_version,
+            )? {
+                Some(TokenWriteSet::Token(inner)) => Some(inner),
+                _ => None,
+            };
+            if let Some(token) = &maybe_token {
+                let table_handle = standardize_address(&table_item.handle.to_string());
+
+                let maybe_table_metadata = table_handle_to_owner.get(&table_handle);
+
+                if let Some(table_metadata) = maybe_table_metadata {
+                    let token_id = offer.token_id.clone();
+                    let token_data_id_struct = token_id.token_data_id;
+                    let collection_data_id_hash =
+                        token_data_id_struct.get_collection_data_id_hash();
+                    let token_data_id_hash = token_data_id_struct.to_hash();
+                    // Basically adding 0x prefix to the previous 2 lines. This is to be consistent with Token V2
+                    let collection_id = token_data_id_struct.get_collection_id();
+                    let token_data_id = token_data_id_struct.to_id();
+                    let collection_name = token_data_id_struct.get_collection_trunc();
+                    let name = token_data_id_struct.get_name_trunc();
+
+                    return Ok(Some(Self {
+                        token_data_id_hash,
+                        property_version: token_id.property_version,
+                        from_address: table_metadata.get_owner_address(),
+                        to_address: offer.get_to_address(),
+                        collection_data_id_hash,
+                        creator_address: token_data_id_struct.get_creator_address(),
+                        collection_name,
+                        name,
+                        amount: token.amount.clone(),
+                        table_handle,
+                        last_transaction_version: txn_version,
+                        last_transaction_timestamp: txn_timestamp,
+                        token_data_id,
+                        collection_id,
+                    }));
+                } else {
+                    tracing::warn!(
+                        transaction_version = txn_version,
+                        table_handle = table_handle,
+                        "Missing table handle metadata for TokenClaim. {:?}",
+                        table_handle_to_owner
+                    );
+                }
+            } else {
+                tracing::warn!(
+                    transaction_version = txn_version,
+                    value_type = table_item_data.value_type,
+                    value = table_item_data.value,
+                    "Expecting token as value for key = token_offer_id",
+                );
+            }
+        }
+        Ok(None)
+    }
+
+    pub fn from_delete_table_item(
+        table_item: &DeleteTableItem,
+        txn_version: i64,
+        txn_timestamp: chrono::NaiveDateTime,
+        table_handle_to_owner: &TableHandleToOwner,
+        tokens_claimed: &TokenV1Claimed,
+    ) -> anyhow::Result<Option<Self>> {
+        let table_item_data = table_item.data.as_ref().unwrap();
+
+        let maybe_offer = match TokenWriteSet::from_table_item_type(
+            table_item_data.key_type.as_str(),
+            &table_item_data.key,
+            txn_version,
+        )? {
+            Some(TokenWriteSet::TokenOfferId(inner)) => Some(inner),
+            _ => None,
+        };
+        if let Some(offer) = &maybe_offer {
+            let table_handle = standardize_address(&table_item.handle.to_string());
+            let token_data_id = offer.token_id.token_data_id.to_id();
+
+            // Try to find owner from write resources
+            let mut maybe_owner_address = table_handle_to_owner
+                .get(&table_handle)
+                .map(|table_metadata| table_metadata.get_owner_address());
+
+            // If table handle isn't in TableHandleToOwner, try to find owner from token v1 claim events
+            if maybe_owner_address.is_none() {
+                if let Some(token_claimed) = tokens_claimed.get(&token_data_id) {
+                    maybe_owner_address = token_claimed.from_address.clone();
+                }
+            }
+
+            let owner_address = maybe_owner_address.unwrap_or_else(|| {
+                panic!(
+                    "Missing table handle metadata for claim. \
+                        Version: {}, table handle for PendingClaims: {}, all metadata: {:?} \
+                        Missing token data id in token claim event. \
+                        token_data_id: {}, all token claim events: {:?}",
+                    txn_version, table_handle, table_handle_to_owner, token_data_id, tokens_claimed
+                )
+            });
+
+            let token_id = offer.token_id.clone();
+            let token_data_id_struct = token_id.token_data_id;
+            let collection_data_id_hash = token_data_id_struct.get_collection_data_id_hash();
+            let token_data_id_hash = token_data_id_struct.to_hash();
+            // Basically adding 0x prefix to the previous 2 lines. This is to be consistent with Token V2
+            let collection_id = token_data_id_struct.get_collection_id();
+            let token_data_id = token_data_id_struct.to_id();
+            let collection_name = token_data_id_struct.get_collection_trunc();
+            let name = token_data_id_struct.get_name_trunc();
+
+            return Ok(Some(Self {
+                token_data_id_hash,
+                property_version: token_id.property_version,
+                from_address: owner_address,
+                to_address: offer.get_to_address(),
+                collection_data_id_hash,
+                creator_address: token_data_id_struct.get_creator_address(),
+                collection_name,
+                name,
+                amount: BigDecimal::zero(),
+                table_handle,
+                last_transaction_version: txn_version,
+                last_transaction_timestamp: txn_timestamp,
+                token_data_id,
+                collection_id,
+            }));
+        }
+        Ok(None)
+    }
+}
+
+pub trait CurrentTokenPendingClaimConvertible {
+    fn from_base(base_item: CurrentTokenPendingClaim) -> Self;
+}
+
+// Parquet Model
+
+#[derive(
+    Allocative, Clone, Debug, Default, Deserialize, FieldCount, ParquetRecordWriter, Serialize,
+)]
+pub struct ParquetCurrentTokenPendingClaim {
+    pub token_data_id_hash: String,
+    pub property_version: u64,
+    pub from_address: String,
+    pub to_address: String,
+    pub collection_data_id_hash: String,
+    pub creator_address: String,
+    pub collection_name: String,
+    pub name: String,
+    pub amount: String, // String format of BigDecimal
+    pub table_handle: String,
+    pub last_transaction_version: i64,
+    #[allocative(skip)]
+    pub last_transaction_timestamp: chrono::NaiveDateTime,
+    pub token_data_id: String,
+    pub collection_id: String,
+}
+
+impl NamedTable for ParquetCurrentTokenPendingClaim {
+    const TABLE_NAME: &'static str = "current_token_pending_claims";
+}
+
+impl HasVersion for ParquetCurrentTokenPendingClaim {
+    fn version(&self) -> i64 {
+        self.last_transaction_version
+    }
+}
+
+impl GetTimeStamp for ParquetCurrentTokenPendingClaim {
+    fn get_timestamp(&self) -> chrono::NaiveDateTime {
+        self.last_transaction_timestamp
+    }
+}
+
+impl CurrentTokenPendingClaimConvertible for ParquetCurrentTokenPendingClaim {
+    fn from_base(base_item: CurrentTokenPendingClaim) -> Self {
+        Self {
+            token_data_id_hash: base_item.token_data_id_hash,
+            property_version: base_item
+                .property_version
+                .to_u64()
+                .expect("Failed to convert property_version to u64"),
+            from_address: base_item.from_address,
+            to_address: base_item.to_address,
+            collection_data_id_hash: base_item.collection_data_id_hash,
+            creator_address: base_item.creator_address,
+            collection_name: base_item.collection_name,
+            name: base_item.name,
+            amount: base_item.amount.to_string(), // (assuming amount is non-critical)
+            table_handle: base_item.table_handle,
+            last_transaction_version: base_item.last_transaction_version,
+            last_transaction_timestamp: base_item.last_transaction_timestamp,
+            token_data_id: base_item.token_data_id,
+            collection_id: base_item.collection_id,
+        }
+    }
+}
+
+// Postgres Model
+
+#[derive(
+    Clone, Debug, Deserialize, Eq, FieldCount, Identifiable, Insertable, PartialEq, Serialize,
+)]
+#[diesel(primary_key(token_data_id_hash, property_version, from_address, to_address))]
+#[diesel(table_name = current_token_pending_claims)]
+pub struct PostgresCurrentTokenPendingClaim {
+    pub token_data_id_hash: String,
+    pub property_version: BigDecimal,
+    pub from_address: String,
+    pub to_address: String,
+    pub collection_data_id_hash: String,
+    pub creator_address: String,
+    pub collection_name: String,
+    pub name: String,
+    pub amount: BigDecimal,
+    pub table_handle: String,
+    pub last_transaction_version: i64,
+    pub last_transaction_timestamp: chrono::NaiveDateTime,
+    pub token_data_id: String,
+    pub collection_id: String,
+}
+
+impl Ord for PostgresCurrentTokenPendingClaim {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.token_data_id_hash
+            .cmp(&other.token_data_id_hash)
+            .then(self.property_version.cmp(&other.property_version))
+            .then(self.from_address.cmp(&other.from_address))
+            .then(self.to_address.cmp(&other.to_address))
+    }
+}
+
+impl PartialOrd for PostgresCurrentTokenPendingClaim {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl CurrentTokenPendingClaimConvertible for PostgresCurrentTokenPendingClaim {
+    fn from_base(base_item: CurrentTokenPendingClaim) -> Self {
+        Self {
+            token_data_id_hash: base_item.token_data_id_hash,
+            property_version: base_item.property_version,
+            from_address: base_item.from_address,
+            to_address: base_item.to_address,
+            collection_data_id_hash: base_item.collection_data_id_hash,
+            creator_address: base_item.creator_address,
+            collection_name: base_item.collection_name,
+            name: base_item.name,
+            amount: base_item.amount,
+            table_handle: base_item.table_handle,
+            last_transaction_version: base_item.last_transaction_version,
+            last_transaction_timestamp: base_item.last_transaction_timestamp,
+            token_data_id: base_item.token_data_id,
+            collection_id: base_item.collection_id,
+        }
+    }
+}

--- a/processor/src/db/models/token_v2_models/v1_token_royalty.rs
+++ b/processor/src/db/models/token_v2_models/v1_token_royalty.rs
@@ -1,0 +1,187 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+#![allow(clippy::unused_unit)]
+
+use crate::{
+    bq_analytics::{GetTimeStamp, HasVersion, NamedTable},
+    db::models::token_models::token_utils::TokenWriteSet,
+    schema::current_token_royalty_v1,
+};
+use allocative_derive::Allocative;
+use aptos_protos::transaction::v1::WriteTableItem;
+use bigdecimal::BigDecimal;
+use field_count::FieldCount;
+use parquet_derive::ParquetRecordWriter;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct CurrentTokenRoyaltyV1 {
+    pub token_data_id: String,
+    pub payee_address: String,
+    pub royalty_points_numerator: BigDecimal,
+    pub royalty_points_denominator: BigDecimal,
+    pub last_transaction_version: i64,
+    pub last_transaction_timestamp: chrono::NaiveDateTime,
+}
+
+impl Ord for CurrentTokenRoyaltyV1 {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.token_data_id.cmp(&other.token_data_id)
+    }
+}
+impl PartialOrd for CurrentTokenRoyaltyV1 {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl CurrentTokenRoyaltyV1 {
+    pub fn pk(&self) -> String {
+        self.token_data_id.clone()
+    }
+
+    // Royalty for v2 token is more complicated and not supported yet. For token v2, royalty can be on the collection (default) or on
+    // the token (override).
+    pub fn get_v1_from_write_table_item(
+        write_table_item: &WriteTableItem,
+        transaction_version: i64,
+        transaction_timestamp: chrono::NaiveDateTime,
+    ) -> anyhow::Result<Option<Self>> {
+        let table_item_data = write_table_item.data.as_ref().unwrap();
+
+        let maybe_token_data = match TokenWriteSet::from_table_item_type(
+            table_item_data.value_type.as_str(),
+            &table_item_data.value,
+            transaction_version,
+        )? {
+            Some(TokenWriteSet::TokenData(inner)) => Some(inner),
+            _ => None,
+        };
+
+        if let Some(token_data) = maybe_token_data {
+            let maybe_token_data_id = match TokenWriteSet::from_table_item_type(
+                table_item_data.key_type.as_str(),
+                &table_item_data.key,
+                transaction_version,
+            )? {
+                Some(TokenWriteSet::TokenDataId(inner)) => Some(inner),
+                _ => None,
+            };
+            if let Some(token_data_id_struct) = maybe_token_data_id {
+                // token data id is the 0x{hash} version of the creator, collection name, and token name
+                let token_data_id = token_data_id_struct.to_id();
+                let payee_address = token_data.royalty.get_payee_address();
+                let royalty_points_numerator = token_data.royalty.royalty_points_numerator.clone();
+                let royalty_points_denominator =
+                    token_data.royalty.royalty_points_denominator.clone();
+
+                return Ok(Some(Self {
+                    token_data_id,
+                    payee_address,
+                    royalty_points_numerator,
+                    royalty_points_denominator,
+                    last_transaction_version: transaction_version,
+                    last_transaction_timestamp: transaction_timestamp,
+                }));
+            } else {
+                tracing::warn!(
+                    transaction_version,
+                    key_type = table_item_data.key_type,
+                    key = table_item_data.key,
+                    "Expecting token_data_id as key for value = token_data"
+                );
+            }
+        }
+        Ok(None)
+    }
+}
+
+pub trait CurrentTokenRoyaltyV1Convertible {
+    fn from_base(base_item: CurrentTokenRoyaltyV1) -> Self;
+}
+
+// Parquet Model
+#[derive(
+    Allocative, Clone, Debug, Default, Deserialize, FieldCount, ParquetRecordWriter, Serialize,
+)]
+pub struct ParquetCurrentTokenRoyaltyV1 {
+    pub token_data_id: String,
+    pub payee_address: String,
+    pub royalty_points_numerator: String, // String format of BigDecimal
+    pub royalty_points_denominator: String, // String format of BigDecimal
+    pub last_transaction_version: i64,
+    #[allocative(skip)]
+    pub last_transaction_timestamp: chrono::NaiveDateTime,
+}
+
+impl NamedTable for ParquetCurrentTokenRoyaltyV1 {
+    const TABLE_NAME: &'static str = "current_token_royalties_v1";
+}
+
+impl HasVersion for ParquetCurrentTokenRoyaltyV1 {
+    fn version(&self) -> i64 {
+        self.last_transaction_version
+    }
+}
+
+impl GetTimeStamp for ParquetCurrentTokenRoyaltyV1 {
+    fn get_timestamp(&self) -> chrono::NaiveDateTime {
+        self.last_transaction_timestamp
+    }
+}
+
+impl CurrentTokenRoyaltyV1Convertible for ParquetCurrentTokenRoyaltyV1 {
+    // TODO: consider returning a Result
+    fn from_base(base_item: CurrentTokenRoyaltyV1) -> Self {
+        Self {
+            token_data_id: base_item.token_data_id,
+            payee_address: base_item.payee_address,
+            royalty_points_numerator: base_item.royalty_points_numerator.to_string(),
+            royalty_points_denominator: base_item.royalty_points_denominator.to_string(),
+            last_transaction_version: base_item.last_transaction_version,
+            last_transaction_timestamp: base_item.last_transaction_timestamp,
+        }
+    }
+}
+
+// Postgres Model
+#[derive(
+    Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize, PartialEq, Eq,
+)]
+#[diesel(primary_key(token_data_id))]
+#[diesel(table_name = current_token_royalty_v1)]
+pub struct PostgresCurrentTokenRoyaltyV1 {
+    pub token_data_id: String,
+    pub payee_address: String,
+    pub royalty_points_numerator: BigDecimal,
+    pub royalty_points_denominator: BigDecimal,
+    pub last_transaction_version: i64,
+    pub last_transaction_timestamp: chrono::NaiveDateTime,
+}
+
+impl Ord for PostgresCurrentTokenRoyaltyV1 {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.token_data_id.cmp(&other.token_data_id)
+    }
+}
+impl PartialOrd for PostgresCurrentTokenRoyaltyV1 {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl CurrentTokenRoyaltyV1Convertible for PostgresCurrentTokenRoyaltyV1 {
+    fn from_base(base_item: CurrentTokenRoyaltyV1) -> Self {
+        Self {
+            token_data_id: base_item.token_data_id,
+            payee_address: base_item.payee_address,
+            royalty_points_numerator: base_item.royalty_points_numerator,
+            royalty_points_denominator: base_item.royalty_points_denominator,
+            last_transaction_version: base_item.last_transaction_version,
+            last_transaction_timestamp: base_item.last_transaction_timestamp,
+        }
+    }
+}

--- a/processor/src/db/models/token_v2_models/v2_token_activities.rs
+++ b/processor/src/db/models/token_v2_models/v2_token_activities.rs
@@ -1,0 +1,469 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+#![allow(clippy::unused_unit)]
+
+use crate::{
+    bq_analytics::{GetTimeStamp, HasVersion, NamedTable},
+    db::models::{
+        object_models::v2_object_utils::ObjectAggregatedDataMapping,
+        token_models::token_utils::{TokenDataIdType, TokenEvent},
+        token_v2_models::{
+            token_claims::TokenV1Claimed,
+            v2_token_utils::{TokenStandard, V2TokenEvent},
+        },
+    },
+    schema::token_activities_v2,
+    utils::util::standardize_address,
+};
+use allocative_derive::Allocative;
+use aptos_protos::transaction::v1::Event;
+use bigdecimal::{BigDecimal, One, ToPrimitive, Zero};
+use field_count::FieldCount;
+use parquet_derive::ParquetRecordWriter;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TokenActivityV2 {
+    pub transaction_version: i64,
+    pub event_index: i64,
+    pub event_account_address: String,
+    pub token_data_id: String,
+    pub property_version_v1: BigDecimal,
+    pub type_: String,
+    pub from_address: Option<String>,
+    pub to_address: Option<String>,
+    pub token_amount: BigDecimal,
+    pub before_value: Option<String>,
+    pub after_value: Option<String>,
+    pub entry_function_id_str: Option<String>,
+    pub token_standard: String,
+    pub is_fungible_v2: Option<bool>,
+    pub transaction_timestamp: chrono::NaiveDateTime,
+}
+
+/// A simplified TokenActivity (excluded common fields) to reduce code duplication
+#[derive(Clone, Debug)]
+pub struct TokenActivityHelperV1 {
+    pub token_data_id_struct: TokenDataIdType,
+    pub property_version: BigDecimal,
+    pub from_address: Option<String>,
+    pub to_address: Option<String>,
+    pub token_amount: BigDecimal,
+}
+
+/// A simplified TokenActivity (excluded common fields) to reduce code duplication
+struct TokenActivityHelperV2 {
+    pub from_address: Option<String>,
+    pub to_address: Option<String>,
+    pub token_amount: BigDecimal,
+    pub before_value: Option<String>,
+    pub after_value: Option<String>,
+    pub event_type: String,
+}
+
+impl TokenActivityV2 {
+    pub async fn get_nft_v2_from_parsed_event(
+        event: &Event,
+        txn_version: i64,
+        txn_timestamp: chrono::NaiveDateTime,
+        event_index: i64,
+        entry_function_id_str: &Option<String>,
+        token_v2_metadata: &ObjectAggregatedDataMapping,
+    ) -> anyhow::Result<Option<Self>> {
+        let event_type = event.type_str.clone();
+        if let Some(token_event) =
+            &V2TokenEvent::from_event(&event_type, event.data.as_str(), txn_version)?
+        {
+            let event_account_address =
+                standardize_address(&event.key.as_ref().unwrap().account_address);
+            // burn and mint events are attached to the collection. The rest should be attached to the token
+            let token_data_id = match token_event {
+                V2TokenEvent::MintEvent(inner) => inner.get_token_address(),
+                V2TokenEvent::Mint(inner) => inner.get_token_address(),
+                V2TokenEvent::BurnEvent(inner) => inner.get_token_address(),
+                V2TokenEvent::Burn(inner) => inner.get_token_address(),
+                V2TokenEvent::TransferEvent(inner) => inner.get_object_address(),
+                _ => event_account_address.clone(),
+            };
+
+            if let Some(metadata) = token_v2_metadata.get(&token_data_id) {
+                let object_core = &metadata.object.object_core;
+                let token_activity_helper = match token_event {
+                    V2TokenEvent::MintEvent(_) => TokenActivityHelperV2 {
+                        from_address: Some(object_core.get_owner_address()),
+                        to_address: None,
+                        token_amount: BigDecimal::one(),
+                        before_value: None,
+                        after_value: None,
+                        event_type: event_type.clone(),
+                    },
+                    V2TokenEvent::Mint(_) => TokenActivityHelperV2 {
+                        from_address: Some(object_core.get_owner_address()),
+                        to_address: None,
+                        token_amount: BigDecimal::one(),
+                        before_value: None,
+                        after_value: None,
+                        event_type: "0x4::collection::MintEvent".to_string(),
+                    },
+                    V2TokenEvent::TokenMutationEvent(inner) => TokenActivityHelperV2 {
+                        from_address: Some(object_core.get_owner_address()),
+                        to_address: None,
+                        token_amount: BigDecimal::zero(),
+                        before_value: Some(inner.old_value.clone()),
+                        after_value: Some(inner.new_value.clone()),
+                        event_type: event_type.clone(),
+                    },
+                    V2TokenEvent::TokenMutation(inner) => TokenActivityHelperV2 {
+                        from_address: Some(inner.token_address.clone()),
+                        to_address: None,
+                        token_amount: BigDecimal::zero(),
+                        before_value: Some(inner.old_value.clone()),
+                        after_value: Some(inner.new_value.clone()),
+                        event_type: "0x4::collection::MutationEvent".to_string(),
+                    },
+                    V2TokenEvent::BurnEvent(_) => TokenActivityHelperV2 {
+                        from_address: Some(object_core.get_owner_address()),
+                        to_address: None,
+                        token_amount: BigDecimal::one(),
+                        before_value: None,
+                        after_value: None,
+                        event_type: event_type.clone(),
+                    },
+                    V2TokenEvent::Burn(_) => TokenActivityHelperV2 {
+                        from_address: Some(object_core.get_owner_address()),
+                        to_address: None,
+                        token_amount: BigDecimal::one(),
+                        before_value: None,
+                        after_value: None,
+                        event_type: "0x4::collection::BurnEvent".to_string(),
+                    },
+                    V2TokenEvent::TransferEvent(inner) => TokenActivityHelperV2 {
+                        from_address: Some(inner.get_from_address()),
+                        to_address: Some(inner.get_to_address()),
+                        token_amount: BigDecimal::one(),
+                        before_value: None,
+                        after_value: None,
+                        event_type: event_type.clone(),
+                    },
+                };
+                return Ok(Some(Self {
+                    transaction_version: txn_version,
+                    event_index,
+                    event_account_address,
+                    token_data_id,
+                    property_version_v1: BigDecimal::zero(),
+                    type_: token_activity_helper.event_type,
+                    from_address: token_activity_helper.from_address,
+                    to_address: token_activity_helper.to_address,
+                    token_amount: token_activity_helper.token_amount,
+                    before_value: token_activity_helper.before_value,
+                    after_value: token_activity_helper.after_value,
+                    entry_function_id_str: entry_function_id_str.clone(),
+                    token_standard: TokenStandard::V2.to_string(),
+                    is_fungible_v2: None,
+                    transaction_timestamp: txn_timestamp,
+                }));
+            } else {
+                // If the object metadata isn't found in the transaction, then the token was burnt.
+
+                // the new burn event has owner address now!
+                let owner_address = if let V2TokenEvent::Burn(inner) = token_event {
+                    inner.get_previous_owner_address()
+                } else {
+                    // To handle a case with the old burn events, when a token is minted and burnt in the same transaction
+                    None
+                };
+
+                return Ok(Some(Self {
+                    transaction_version: txn_version,
+                    event_index,
+                    event_account_address,
+                    token_data_id,
+                    property_version_v1: BigDecimal::zero(),
+                    type_: event_type,
+                    from_address: owner_address.clone(),
+                    to_address: None,
+                    token_amount: BigDecimal::one(),
+                    before_value: None,
+                    after_value: None,
+                    entry_function_id_str: entry_function_id_str.clone(),
+                    token_standard: TokenStandard::V2.to_string(),
+                    is_fungible_v2: None,
+                    transaction_timestamp: txn_timestamp,
+                }));
+            }
+        }
+        Ok(None)
+    }
+
+    pub fn get_v1_from_parsed_event(
+        event: &Event,
+        txn_version: i64,
+        txn_timestamp: chrono::NaiveDateTime,
+        event_index: i64,
+        entry_function_id_str: &Option<String>,
+        tokens_claimed: &mut TokenV1Claimed,
+    ) -> anyhow::Result<Option<Self>> {
+        let event_type = event.type_str.clone();
+        if let Some(token_event) = &TokenEvent::from_event(&event_type, &event.data, txn_version)? {
+            let event_account_address =
+                standardize_address(&event.key.as_ref().unwrap().account_address);
+            let token_activity_helper = match token_event {
+                TokenEvent::MintTokenEvent(inner) => TokenActivityHelperV1 {
+                    token_data_id_struct: inner.id.clone(),
+                    property_version: BigDecimal::zero(),
+                    from_address: Some(event_account_address.clone()),
+                    to_address: None,
+                    token_amount: inner.amount.clone(),
+                },
+                TokenEvent::Mint(inner) => TokenActivityHelperV1 {
+                    token_data_id_struct: inner.id.clone(),
+                    property_version: BigDecimal::zero(),
+                    from_address: Some(inner.get_account()),
+                    to_address: None,
+                    token_amount: inner.amount.clone(),
+                },
+                TokenEvent::BurnTokenEvent(inner) => TokenActivityHelperV1 {
+                    token_data_id_struct: inner.id.token_data_id.clone(),
+                    property_version: inner.id.property_version.clone(),
+                    from_address: Some(event_account_address.clone()),
+                    to_address: None,
+                    token_amount: inner.amount.clone(),
+                },
+                TokenEvent::Burn(inner) => TokenActivityHelperV1 {
+                    token_data_id_struct: inner.id.token_data_id.clone(),
+                    property_version: inner.id.property_version.clone(),
+                    from_address: Some(inner.get_account()),
+                    to_address: None,
+                    token_amount: inner.amount.clone(),
+                },
+                TokenEvent::MutateTokenPropertyMapEvent(inner) => TokenActivityHelperV1 {
+                    token_data_id_struct: inner.new_id.token_data_id.clone(),
+                    property_version: inner.new_id.property_version.clone(),
+                    from_address: Some(event_account_address.clone()),
+                    to_address: None,
+                    token_amount: BigDecimal::zero(),
+                },
+                TokenEvent::MutatePropertyMap(inner) => TokenActivityHelperV1 {
+                    token_data_id_struct: inner.new_id.token_data_id.clone(),
+                    property_version: inner.new_id.property_version.clone(),
+                    from_address: Some(inner.get_account()),
+                    to_address: None,
+                    token_amount: BigDecimal::zero(),
+                },
+                TokenEvent::WithdrawTokenEvent(inner) => TokenActivityHelperV1 {
+                    token_data_id_struct: inner.id.token_data_id.clone(),
+                    property_version: inner.id.property_version.clone(),
+                    from_address: Some(event_account_address.clone()),
+                    to_address: None,
+                    token_amount: inner.amount.clone(),
+                },
+                TokenEvent::TokenWithdraw(inner) => TokenActivityHelperV1 {
+                    token_data_id_struct: inner.id.token_data_id.clone(),
+                    property_version: inner.id.property_version.clone(),
+                    from_address: Some(inner.get_account()),
+                    to_address: None,
+                    token_amount: inner.amount.clone(),
+                },
+                TokenEvent::DepositTokenEvent(inner) => TokenActivityHelperV1 {
+                    token_data_id_struct: inner.id.token_data_id.clone(),
+                    property_version: inner.id.property_version.clone(),
+                    from_address: None,
+                    to_address: Some(standardize_address(&event_account_address)),
+                    token_amount: inner.amount.clone(),
+                },
+                TokenEvent::TokenDeposit(inner) => TokenActivityHelperV1 {
+                    token_data_id_struct: inner.id.token_data_id.clone(),
+                    property_version: inner.id.property_version.clone(),
+                    from_address: None,
+                    to_address: Some(inner.get_account()),
+                    token_amount: inner.amount.clone(),
+                },
+                TokenEvent::OfferTokenEvent(inner) => TokenActivityHelperV1 {
+                    token_data_id_struct: inner.token_id.token_data_id.clone(),
+                    property_version: inner.token_id.property_version.clone(),
+                    from_address: Some(event_account_address.clone()),
+                    to_address: Some(inner.get_to_address()),
+                    token_amount: inner.amount.clone(),
+                },
+                TokenEvent::CancelTokenOfferEvent(inner) => TokenActivityHelperV1 {
+                    token_data_id_struct: inner.token_id.token_data_id.clone(),
+                    property_version: inner.token_id.property_version.clone(),
+                    from_address: Some(event_account_address.clone()),
+                    to_address: Some(inner.get_to_address()),
+                    token_amount: inner.amount.clone(),
+                },
+                TokenEvent::ClaimTokenEvent(inner) => {
+                    let token_data_id_struct = inner.token_id.token_data_id.clone();
+                    let helper = TokenActivityHelperV1 {
+                        token_data_id_struct: token_data_id_struct.clone(),
+                        property_version: inner.token_id.property_version.clone(),
+                        from_address: Some(event_account_address.clone()),
+                        to_address: Some(inner.get_to_address()),
+                        token_amount: inner.amount.clone(),
+                    };
+                    tokens_claimed.insert(token_data_id_struct.to_id(), helper.clone());
+                    helper
+                },
+                TokenEvent::Offer(inner) => TokenActivityHelperV1 {
+                    token_data_id_struct: inner.token_id.token_data_id.clone(),
+                    property_version: inner.token_id.property_version.clone(),
+                    from_address: Some(inner.get_from_address()),
+                    to_address: Some(inner.get_to_address()),
+                    token_amount: inner.amount.clone(),
+                },
+                TokenEvent::CancelOffer(inner) => TokenActivityHelperV1 {
+                    token_data_id_struct: inner.token_id.token_data_id.clone(),
+                    property_version: inner.token_id.property_version.clone(),
+                    from_address: Some(inner.get_from_address()),
+                    to_address: Some(inner.get_to_address()),
+                    token_amount: inner.amount.clone(),
+                },
+                TokenEvent::Claim(inner) => {
+                    let token_data_id_struct = inner.token_id.token_data_id.clone();
+                    let helper = TokenActivityHelperV1 {
+                        token_data_id_struct: token_data_id_struct.clone(),
+                        property_version: inner.token_id.property_version.clone(),
+                        from_address: Some(inner.get_from_address()),
+                        to_address: Some(inner.get_to_address()),
+                        token_amount: inner.amount.clone(),
+                    };
+                    tokens_claimed.insert(token_data_id_struct.to_id(), helper.clone());
+                    helper
+                },
+            };
+            let token_data_id_struct = token_activity_helper.token_data_id_struct;
+            return Ok(Some(Self {
+                transaction_version: txn_version,
+                event_index,
+                event_account_address,
+                token_data_id: token_data_id_struct.to_id(),
+                property_version_v1: token_activity_helper.property_version,
+                type_: event_type,
+                from_address: token_activity_helper.from_address,
+                to_address: token_activity_helper.to_address,
+                token_amount: token_activity_helper.token_amount,
+                before_value: None,
+                after_value: None,
+                entry_function_id_str: entry_function_id_str.clone(),
+                token_standard: TokenStandard::V1.to_string(),
+                is_fungible_v2: None,
+                transaction_timestamp: txn_timestamp,
+            }));
+        }
+        Ok(None)
+    }
+}
+
+pub trait TokenActivityV2Convertible {
+    fn from_base(base_item: TokenActivityV2) -> Self;
+}
+
+// Parquet Model
+#[derive(
+    Allocative, Clone, Debug, Default, Deserialize, FieldCount, ParquetRecordWriter, Serialize,
+)]
+pub struct ParquetTokenActivityV2 {
+    pub txn_version: i64,
+    pub event_index: i64,
+    pub event_account_address: String,
+    pub token_data_id: String,
+    pub property_version_v1: u64, // BigDecimal
+    pub type_: String,
+    pub from_address: Option<String>,
+    pub to_address: Option<String>,
+    pub token_amount: String, // BigDecimal
+    pub before_value: Option<String>,
+    pub after_value: Option<String>,
+    pub entry_function_id_str: Option<String>,
+    pub token_standard: String,
+    pub is_fungible_v2: Option<bool>,
+    #[allocative(skip)]
+    pub block_timestamp: chrono::NaiveDateTime,
+}
+
+impl NamedTable for ParquetTokenActivityV2 {
+    const TABLE_NAME: &'static str = "token_activities_v2";
+}
+
+impl HasVersion for ParquetTokenActivityV2 {
+    fn version(&self) -> i64 {
+        self.txn_version
+    }
+}
+
+impl GetTimeStamp for ParquetTokenActivityV2 {
+    fn get_timestamp(&self) -> chrono::NaiveDateTime {
+        self.block_timestamp
+    }
+}
+
+impl TokenActivityV2Convertible for ParquetTokenActivityV2 {
+    // TODO: consider returning a Result
+    fn from_base(base_item: TokenActivityV2) -> Self {
+        Self {
+            txn_version: base_item.transaction_version,
+            event_index: base_item.event_index,
+            event_account_address: base_item.event_account_address,
+            token_data_id: base_item.token_data_id,
+            property_version_v1: base_item.property_version_v1.to_u64().unwrap(),
+            type_: base_item.type_,
+            from_address: base_item.from_address,
+            to_address: base_item.to_address,
+            token_amount: base_item.token_amount.to_string(),
+            before_value: base_item.before_value,
+            after_value: base_item.after_value,
+            entry_function_id_str: base_item.entry_function_id_str,
+            token_standard: base_item.token_standard,
+            is_fungible_v2: base_item.is_fungible_v2,
+            block_timestamp: base_item.transaction_timestamp,
+        }
+    }
+}
+
+// Postgres Model
+#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(transaction_version, event_index))]
+#[diesel(table_name = token_activities_v2)]
+pub struct PostgresTokenActivityV2 {
+    pub transaction_version: i64,
+    pub event_index: i64,
+    pub event_account_address: String,
+    pub token_data_id: String,
+    pub property_version_v1: BigDecimal,
+    pub type_: String,
+    pub from_address: Option<String>,
+    pub to_address: Option<String>,
+    pub token_amount: BigDecimal,
+    pub before_value: Option<String>,
+    pub after_value: Option<String>,
+    pub entry_function_id_str: Option<String>,
+    pub token_standard: String,
+    pub is_fungible_v2: Option<bool>,
+    pub transaction_timestamp: chrono::NaiveDateTime,
+}
+
+impl TokenActivityV2Convertible for PostgresTokenActivityV2 {
+    fn from_base(base_item: TokenActivityV2) -> Self {
+        Self {
+            transaction_version: base_item.transaction_version,
+            event_index: base_item.event_index,
+            event_account_address: base_item.event_account_address,
+            token_data_id: base_item.token_data_id,
+            property_version_v1: base_item.property_version_v1,
+            type_: base_item.type_,
+            from_address: base_item.from_address,
+            to_address: base_item.to_address,
+            token_amount: base_item.token_amount,
+            before_value: base_item.before_value,
+            after_value: base_item.after_value,
+            entry_function_id_str: base_item.entry_function_id_str,
+            token_standard: base_item.token_standard,
+            is_fungible_v2: base_item.is_fungible_v2,
+            transaction_timestamp: base_item.transaction_timestamp,
+        }
+    }
+}

--- a/processor/src/db/models/token_v2_models/v2_token_datas.rs
+++ b/processor/src/db/models/token_v2_models/v2_token_datas.rs
@@ -1,0 +1,531 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+#![allow(clippy::unused_unit)]
+
+use crate::{
+    bq_analytics::{GetTimeStamp, HasVersion, NamedTable},
+    db::{
+        models::{
+            object_models::v2_object_utils::ObjectAggregatedDataMapping,
+            token_models::token_utils::TokenWriteSet,
+            token_v2_models::v2_token_utils::{TokenStandard, TokenV2, TokenV2Burned},
+            DEFAULT_NONE,
+        },
+        resources::FromWriteResource,
+    },
+    schema::{current_token_datas_v2, token_datas_v2},
+    utils::util::standardize_address,
+};
+use allocative_derive::Allocative;
+use anyhow::Context;
+use aptos_protos::transaction::v1::{DeleteResource, WriteResource, WriteTableItem};
+use bigdecimal::BigDecimal;
+use diesel::prelude::*;
+use field_count::FieldCount;
+use parquet_derive::ParquetRecordWriter;
+use serde::{Deserialize, Serialize};
+use tracing::error;
+
+pub type CurrentTokenDataV2PK = String;
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct TokenDataV2 {
+    pub transaction_version: i64,
+    pub write_set_change_index: i64,
+    pub token_data_id: String,
+    pub collection_id: String,
+    pub token_name: String,
+    pub maximum: Option<BigDecimal>,
+    pub supply: Option<BigDecimal>,
+    pub largest_property_version_v1: Option<BigDecimal>,
+    pub token_uri: String,
+    pub token_properties: serde_json::Value,
+    pub description: String,
+    pub token_standard: String,
+    pub is_fungible_v2: Option<bool>,
+    pub transaction_timestamp: chrono::NaiveDateTime,
+    // Deprecated, but still here for backwards compatibility
+    pub decimals: Option<i64>,
+    // Here for consistency but we don't need to actually fill it
+    pub is_deleted_v2: Option<bool>,
+}
+
+pub trait TokenDataV2Convertible {
+    fn from_base(base_item: TokenDataV2) -> Self;
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CurrentTokenDataV2 {
+    pub token_data_id: String,
+    pub collection_id: String,
+    pub token_name: String,
+    pub maximum: Option<BigDecimal>,
+    pub supply: Option<BigDecimal>,
+    pub largest_property_version_v1: Option<BigDecimal>,
+    pub token_uri: String,
+    pub token_properties: serde_json::Value,
+    pub description: String,
+    pub token_standard: String,
+    pub is_fungible_v2: Option<bool>,
+    pub last_transaction_version: i64,
+    pub last_transaction_timestamp: chrono::NaiveDateTime,
+    // Deprecated, but still here for backwards compatibility
+    pub decimals: Option<i64>,
+    pub is_deleted_v2: Option<bool>,
+}
+
+pub trait CurrentTokenDataV2Convertible {
+    fn from_base(base_item: CurrentTokenDataV2) -> Self;
+}
+
+impl TokenDataV2 {
+    // TODO: remove the useless_asref lint when new clippy nighly is released.
+    #[allow(clippy::useless_asref)]
+    pub fn get_v2_from_write_resource(
+        write_resource: &WriteResource,
+        txn_version: i64,
+        write_set_change_index: i64,
+        txn_timestamp: chrono::NaiveDateTime,
+        object_metadatas: &ObjectAggregatedDataMapping,
+    ) -> anyhow::Result<Option<(Self, CurrentTokenDataV2)>> {
+        if let Some(inner) = &TokenV2::from_write_resource(write_resource)? {
+            let token_data_id = standardize_address(&write_resource.address.to_string());
+            let mut token_name = inner.get_name_trunc();
+            let is_fungible_v2;
+            // Get token properties from 0x4::property_map::PropertyMap
+            let mut token_properties = serde_json::Value::Null;
+            if let Some(object_metadata) = object_metadatas.get(&token_data_id) {
+                let fungible_asset_metadata = object_metadata.fungible_asset_metadata.as_ref();
+                if fungible_asset_metadata.is_some() {
+                    is_fungible_v2 = Some(true);
+                } else {
+                    is_fungible_v2 = Some(false);
+                }
+                token_properties = object_metadata
+                    .property_map
+                    .as_ref()
+                    .map(|m| m.inner.clone())
+                    .unwrap_or(token_properties);
+                // In aggregator V2 name is now derived from a separate struct
+                if let Some(token_identifier) = object_metadata.token_identifier.as_ref() {
+                    token_name = token_identifier.get_name_trunc();
+                }
+            } else {
+                // ObjectCore should not be missing, returning from entire function early
+                return Ok(None);
+            }
+
+            let collection_id = inner.get_collection_address();
+            let token_uri = inner.get_uri_trunc();
+
+            Ok(Some((
+                Self {
+                    transaction_version: txn_version,
+                    write_set_change_index,
+                    token_data_id: token_data_id.clone(),
+                    collection_id: collection_id.clone(),
+                    token_name: token_name.clone(),
+                    maximum: None,
+                    supply: None,
+                    largest_property_version_v1: None,
+                    token_uri: token_uri.clone(),
+                    token_properties: token_properties.clone(),
+                    description: inner.description.clone(),
+                    token_standard: TokenStandard::V2.to_string(),
+                    is_fungible_v2,
+                    transaction_timestamp: txn_timestamp,
+                    decimals: None,
+                    is_deleted_v2: None,
+                },
+                CurrentTokenDataV2 {
+                    token_data_id,
+                    collection_id,
+                    token_name,
+                    maximum: None,
+                    supply: None,
+                    largest_property_version_v1: None,
+                    token_uri,
+                    token_properties,
+                    description: inner.description.clone(),
+                    token_standard: TokenStandard::V2.to_string(),
+                    is_fungible_v2,
+                    last_transaction_version: txn_version,
+                    last_transaction_timestamp: txn_timestamp,
+                    decimals: None,
+                    is_deleted_v2: Some(false),
+                },
+            )))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// This handles the case where token is burned but objectCore is still there
+    pub async fn get_burned_nft_v2_from_write_resource(
+        write_resource: &WriteResource,
+        txn_version: i64,
+        txn_timestamp: chrono::NaiveDateTime,
+        tokens_burned: &TokenV2Burned,
+    ) -> anyhow::Result<Option<CurrentTokenDataV2>> {
+        let token_data_id = standardize_address(&write_resource.address.to_string());
+        // reminder that v1 events won't get to this codepath
+        if let Some(burn_event_v2) = tokens_burned.get(&standardize_address(&token_data_id)) {
+            Ok(Some(CurrentTokenDataV2 {
+                token_data_id,
+                collection_id: burn_event_v2.get_collection_address(),
+                token_name: "".to_string(),
+                maximum: None,
+                supply: None,
+                largest_property_version_v1: None,
+                token_uri: "".to_string(),
+                token_properties: serde_json::Value::Null,
+                description: "".to_string(),
+                token_standard: TokenStandard::V2.to_string(),
+                is_fungible_v2: Some(false),
+                last_transaction_version: txn_version,
+                last_transaction_timestamp: txn_timestamp,
+                decimals: None,
+                is_deleted_v2: Some(true),
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// This handles the case where token is burned and objectCore is deleted
+    pub async fn get_burned_nft_v2_from_delete_resource(
+        delete_resource: &DeleteResource,
+        txn_version: i64,
+        txn_timestamp: chrono::NaiveDateTime,
+        tokens_burned: &TokenV2Burned,
+    ) -> anyhow::Result<Option<CurrentTokenDataV2>> {
+        let token_data_id = standardize_address(&delete_resource.address.to_string());
+        // reminder that v1 events won't get to this codepath
+        if let Some(burn_event_v2) = tokens_burned.get(&standardize_address(&token_data_id)) {
+            Ok(Some(CurrentTokenDataV2 {
+                token_data_id,
+                collection_id: burn_event_v2.get_collection_address(),
+                token_name: "".to_string(),
+                maximum: None,
+                supply: None,
+                largest_property_version_v1: None,
+                token_uri: "".to_string(),
+                token_properties: serde_json::Value::Null,
+                description: "".to_string(),
+                token_standard: TokenStandard::V2.to_string(),
+                is_fungible_v2: Some(false),
+                last_transaction_version: txn_version,
+                last_transaction_timestamp: txn_timestamp,
+                decimals: None,
+                is_deleted_v2: Some(true),
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn get_v1_from_write_table_item(
+        table_item: &WriteTableItem,
+        txn_version: i64,
+        write_set_change_index: i64,
+        txn_timestamp: chrono::NaiveDateTime,
+    ) -> anyhow::Result<Option<(Self, CurrentTokenDataV2)>> {
+        let table_item_data = table_item.data.as_ref().unwrap();
+
+        let maybe_token_data = match TokenWriteSet::from_table_item_type(
+            table_item_data.value_type.as_str(),
+            &table_item_data.value,
+            txn_version,
+        )? {
+            Some(TokenWriteSet::TokenData(inner)) => Some(inner),
+            _ => None,
+        };
+
+        if let Some(token_data) = maybe_token_data {
+            let maybe_token_data_id = match TokenWriteSet::from_table_item_type(
+                table_item_data.key_type.as_str(),
+                &table_item_data.key,
+                txn_version,
+            )? {
+                Some(TokenWriteSet::TokenDataId(inner)) => Some(inner),
+                _ => None,
+            };
+            if let Some(token_data_id_struct) = maybe_token_data_id {
+                let collection_id = token_data_id_struct.get_collection_id();
+                let token_data_id = token_data_id_struct.to_id();
+                let token_name = token_data_id_struct.get_name_trunc();
+                let token_uri = token_data.get_uri_trunc();
+
+                return Ok(Some((
+                    Self {
+                        transaction_version: txn_version,
+                        write_set_change_index,
+                        token_data_id: token_data_id.clone(),
+                        collection_id: collection_id.clone(),
+                        token_name: token_name.clone(),
+                        maximum: Some(token_data.maximum.clone()),
+                        supply: Some(token_data.supply.clone()),
+                        largest_property_version_v1: Some(
+                            token_data.largest_property_version.clone(),
+                        ),
+                        token_uri: token_uri.clone(),
+                        token_properties: token_data.default_properties.clone(),
+                        description: token_data.description.clone(),
+                        token_standard: TokenStandard::V1.to_string(),
+                        is_fungible_v2: None,
+                        transaction_timestamp: txn_timestamp,
+                        decimals: None,
+                        is_deleted_v2: None,
+                    },
+                    CurrentTokenDataV2 {
+                        token_data_id,
+                        collection_id,
+                        token_name,
+                        maximum: Some(token_data.maximum),
+                        supply: Some(token_data.supply),
+                        largest_property_version_v1: Some(token_data.largest_property_version),
+                        token_uri,
+                        token_properties: token_data.default_properties,
+                        description: token_data.description,
+                        token_standard: TokenStandard::V1.to_string(),
+                        is_fungible_v2: None,
+                        last_transaction_version: txn_version,
+                        last_transaction_timestamp: txn_timestamp,
+                        decimals: None,
+                        is_deleted_v2: None,
+                    },
+                )));
+            } else {
+                tracing::warn!(
+                    transaction_version = txn_version,
+                    key_type = table_item_data.key_type,
+                    key = table_item_data.key,
+                    "Expecting token_data_id as key for value = token_data"
+                );
+            }
+        }
+        Ok(None)
+    }
+}
+
+// Parquet Model
+#[derive(Allocative, Clone, Debug, Default, Deserialize, ParquetRecordWriter, Serialize)]
+pub struct ParquetTokenDataV2 {
+    pub txn_version: i64,
+    pub write_set_change_index: i64,
+    pub token_data_id: String,
+    pub collection_id: String,
+    pub token_name: String,
+    pub largest_property_version_v1: Option<String>, // String format of BigDecimal
+    pub token_uri: String,
+    pub token_properties: String,
+    pub description: String,
+    pub token_standard: String,
+    pub is_fungible_v2: Option<bool>,
+    #[allocative(skip)]
+    pub block_timestamp: chrono::NaiveDateTime,
+    pub is_deleted_v2: Option<bool>,
+}
+
+impl NamedTable for ParquetTokenDataV2 {
+    const TABLE_NAME: &'static str = "token_datas_v2";
+}
+
+impl HasVersion for ParquetTokenDataV2 {
+    fn version(&self) -> i64 {
+        self.txn_version
+    }
+}
+
+impl GetTimeStamp for ParquetTokenDataV2 {
+    fn get_timestamp(&self) -> chrono::NaiveDateTime {
+        self.block_timestamp
+    }
+}
+
+impl TokenDataV2Convertible for ParquetTokenDataV2 {
+    fn from_base(base_item: TokenDataV2) -> Self {
+        Self {
+            txn_version: base_item.transaction_version,
+            write_set_change_index: base_item.write_set_change_index,
+            token_data_id: base_item.token_data_id,
+            collection_id: base_item.collection_id,
+            token_name: base_item.token_name,
+            largest_property_version_v1: base_item
+                .largest_property_version_v1
+                .map(|v| v.to_string()),
+            token_uri: base_item.token_uri,
+            token_properties: canonical_json::to_string(&base_item.token_properties.clone())
+                .context("Failed to serialize token properties")
+                .unwrap(),
+            description: base_item.description,
+            token_standard: base_item.token_standard,
+            is_fungible_v2: base_item.is_fungible_v2,
+            block_timestamp: base_item.transaction_timestamp,
+            is_deleted_v2: base_item.is_deleted_v2,
+        }
+    }
+}
+
+#[derive(Allocative, Clone, Debug, Default, Deserialize, ParquetRecordWriter, Serialize)]
+pub struct ParquetCurrentTokenDataV2 {
+    pub token_data_id: String,
+    pub collection_id: String,
+    pub token_name: String,
+    pub maximum: Option<String>,                     // BigDecimal
+    pub supply: Option<String>,                      // BigDecimal
+    pub largest_property_version_v1: Option<String>, // String format of BigDecimal
+    pub token_uri: String,
+    pub token_properties: String, // serde_json::Value,
+    pub description: String,
+    pub token_standard: String,
+    pub is_fungible_v2: Option<bool>,
+    pub last_transaction_version: i64,
+    #[allocative(skip)]
+    pub last_transaction_timestamp: chrono::NaiveDateTime,
+    // Deprecated, but still here for backwards compatibility
+    pub decimals: Option<i64>,
+    pub is_deleted_v2: Option<bool>,
+}
+
+impl NamedTable for ParquetCurrentTokenDataV2 {
+    const TABLE_NAME: &'static str = "current_token_datas_v2";
+}
+
+impl HasVersion for ParquetCurrentTokenDataV2 {
+    fn version(&self) -> i64 {
+        self.last_transaction_version
+    }
+}
+
+impl GetTimeStamp for ParquetCurrentTokenDataV2 {
+    fn get_timestamp(&self) -> chrono::NaiveDateTime {
+        self.last_transaction_timestamp
+    }
+}
+
+impl CurrentTokenDataV2Convertible for ParquetCurrentTokenDataV2 {
+    fn from_base(base_item: CurrentTokenDataV2) -> Self {
+        Self {
+            token_data_id: base_item.token_data_id,
+            collection_id: base_item.collection_id,
+            token_name: base_item.token_name,
+            maximum: base_item.maximum.map(|v| v.to_string()),
+            supply: base_item.supply.map(|v| v.to_string()),
+            largest_property_version_v1: base_item
+                .largest_property_version_v1
+                .map(|v| v.to_string()),
+            token_uri: base_item.token_uri,
+            token_properties: canonical_json::to_string(&base_item.token_properties)
+                .unwrap_or_else(|_| {
+                    error!(
+                        "Failed to serialize token_properties to JSON: {:?}",
+                        base_item.token_properties
+                    );
+                    DEFAULT_NONE.to_string()
+                }),
+            description: base_item.description,
+            token_standard: base_item.token_standard,
+            is_fungible_v2: base_item.is_fungible_v2,
+            last_transaction_version: base_item.last_transaction_version,
+            last_transaction_timestamp: base_item.last_transaction_timestamp,
+            decimals: base_item.decimals,
+            is_deleted_v2: base_item.is_deleted_v2,
+        }
+    }
+}
+
+// Postgres Model
+
+#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(transaction_version, write_set_change_index))]
+#[diesel(table_name = token_datas_v2)]
+pub struct PostgresTokenDataV2 {
+    pub transaction_version: i64,
+    pub write_set_change_index: i64,
+    pub token_data_id: String,
+    pub collection_id: String,
+    pub token_name: String,
+    pub maximum: Option<BigDecimal>,
+    pub supply: Option<BigDecimal>,
+    pub largest_property_version_v1: Option<BigDecimal>,
+    pub token_uri: String,
+    pub token_properties: serde_json::Value,
+    pub description: String,
+    pub token_standard: String,
+    pub is_fungible_v2: Option<bool>,
+    pub transaction_timestamp: chrono::NaiveDateTime,
+    // Deprecated, but still here for backwards compatibility
+    pub decimals: Option<i64>,
+    // Here for consistency but we don't need to actually fill it
+    // pub is_deleted_v2: Option<bool>,
+}
+
+impl TokenDataV2Convertible for PostgresTokenDataV2 {
+    fn from_base(base_item: TokenDataV2) -> Self {
+        Self {
+            transaction_version: base_item.transaction_version,
+            write_set_change_index: base_item.write_set_change_index,
+            token_data_id: base_item.token_data_id,
+            collection_id: base_item.collection_id,
+            token_name: base_item.token_name,
+            maximum: base_item.maximum,
+            supply: base_item.supply,
+            largest_property_version_v1: base_item.largest_property_version_v1,
+            token_uri: base_item.token_uri,
+            token_properties: base_item.token_properties,
+            description: base_item.description,
+            token_standard: base_item.token_standard,
+            is_fungible_v2: base_item.is_fungible_v2,
+            transaction_timestamp: base_item.transaction_timestamp,
+            decimals: base_item.decimals,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(token_data_id))]
+#[diesel(table_name = current_token_datas_v2)]
+pub struct PostgresCurrentTokenDataV2 {
+    pub token_data_id: String,
+    pub collection_id: String,
+    pub token_name: String,
+    pub maximum: Option<BigDecimal>,
+    pub supply: Option<BigDecimal>,
+    pub largest_property_version_v1: Option<BigDecimal>,
+    pub token_uri: String,
+    pub token_properties: serde_json::Value,
+    pub description: String,
+    pub token_standard: String,
+    pub is_fungible_v2: Option<bool>,
+    pub last_transaction_version: i64,
+    pub last_transaction_timestamp: chrono::NaiveDateTime,
+    // Deprecated, but still here for backwards compatibility
+    pub decimals: Option<i64>,
+    pub is_deleted_v2: Option<bool>,
+}
+
+impl CurrentTokenDataV2Convertible for PostgresCurrentTokenDataV2 {
+    fn from_base(base_item: CurrentTokenDataV2) -> Self {
+        Self {
+            token_data_id: base_item.token_data_id,
+            collection_id: base_item.collection_id,
+            token_name: base_item.token_name,
+            maximum: base_item.maximum,
+            supply: base_item.supply,
+            largest_property_version_v1: base_item.largest_property_version_v1,
+            token_uri: base_item.token_uri,
+            token_properties: base_item.token_properties,
+            description: base_item.description,
+            token_standard: base_item.token_standard,
+            is_fungible_v2: base_item.is_fungible_v2,
+            last_transaction_version: base_item.last_transaction_version,
+            last_transaction_timestamp: base_item.last_transaction_timestamp,
+            decimals: base_item.decimals,
+            is_deleted_v2: base_item.is_deleted_v2,
+        }
+    }
+}

--- a/processor/src/db/models/token_v2_models/v2_token_metadata.rs
+++ b/processor/src/db/models/token_v2_models/v2_token_metadata.rs
@@ -1,0 +1,176 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+#![allow(clippy::unused_unit)]
+
+use crate::{
+    bq_analytics::{GetTimeStamp, HasVersion, NamedTable},
+    db::{
+        models::{
+            object_models::v2_object_utils::ObjectAggregatedDataMapping,
+            old_default_models::postgres_move_resources::MoveResource,
+            token_models::token_utils::NAME_LENGTH, DEFAULT_NONE,
+        },
+        resources::{COIN_ADDR, TOKEN_ADDR, TOKEN_V2_ADDR},
+    },
+    schema::current_token_v2_metadata,
+    utils::util::{standardize_address, truncate_str},
+};
+use allocative_derive::Allocative;
+use anyhow::Context;
+use aptos_protos::transaction::v1::WriteResource;
+use field_count::FieldCount;
+use parquet_derive::ParquetRecordWriter;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tracing::error;
+
+// PK of current_objects, i.e. object_address, resource_type
+pub type CurrentTokenV2MetadataPK = (String, String);
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CurrentTokenV2Metadata {
+    pub object_address: String,
+    pub resource_type: String,
+    pub data: Value,
+    pub state_key_hash: String,
+    pub last_transaction_version: i64,
+    pub last_transaction_timestamp: chrono::NaiveDateTime,
+}
+
+impl Ord for CurrentTokenV2Metadata {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.object_address
+            .cmp(&other.object_address)
+            .then(self.resource_type.cmp(&other.resource_type))
+    }
+}
+impl PartialOrd for CurrentTokenV2Metadata {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl CurrentTokenV2Metadata {
+    /// Parsing unknown resources with 0x4::token::Token
+    pub fn from_write_resource(
+        write_resource: &WriteResource,
+        txn_version: i64,
+        object_metadatas: &ObjectAggregatedDataMapping,
+        txn_timestamp: chrono::NaiveDateTime,
+    ) -> anyhow::Result<Option<Self>> {
+        let object_address = standardize_address(&write_resource.address.to_string());
+        if let Some(object_data) = object_metadatas.get(&object_address) {
+            // checking if token_v2
+            if object_data.token.is_some() {
+                let move_tag =
+                    MoveResource::convert_move_struct_tag(write_resource.r#type.as_ref().unwrap());
+                let resource_type_addr = move_tag.get_address();
+                if matches!(
+                    resource_type_addr.as_str(),
+                    COIN_ADDR | TOKEN_ADDR | TOKEN_V2_ADDR
+                ) {
+                    return Ok(None);
+                }
+
+                let resource = MoveResource::from_write_resource(write_resource, 0, txn_version, 0);
+
+                let state_key_hash = object_data.object.get_state_key_hash();
+                if state_key_hash != resource.state_key_hash {
+                    return Ok(None);
+                }
+
+                let resource_type = truncate_str(&resource.type_, NAME_LENGTH);
+                return Ok(Some(CurrentTokenV2Metadata {
+                    object_address,
+                    resource_type,
+                    data: resource
+                        .data
+                        .context("data must be present in write resource")?,
+                    state_key_hash: resource.state_key_hash,
+                    last_transaction_version: txn_version,
+                    last_transaction_timestamp: txn_timestamp,
+                }));
+            }
+        }
+        Ok(None)
+    }
+}
+
+pub trait CurrentTokenV2MetadataConvertible {
+    fn from_base(base_item: CurrentTokenV2Metadata) -> Self;
+}
+
+// Parquet Model
+
+#[derive(
+    Allocative, Clone, Debug, Default, Deserialize, FieldCount, ParquetRecordWriter, Serialize,
+)]
+pub struct ParquetCurrentTokenV2Metadata {
+    pub object_address: String,
+    pub resource_type: String,
+    pub data: String,
+    pub state_key_hash: String,
+    pub last_transaction_version: i64,
+    #[allocative(skip)]
+    pub last_transaction_timestamp: chrono::NaiveDateTime,
+}
+impl NamedTable for ParquetCurrentTokenV2Metadata {
+    const TABLE_NAME: &'static str = "current_token_v2_metadata";
+}
+
+impl HasVersion for ParquetCurrentTokenV2Metadata {
+    fn version(&self) -> i64 {
+        self.last_transaction_version
+    }
+}
+
+impl GetTimeStamp for ParquetCurrentTokenV2Metadata {
+    fn get_timestamp(&self) -> chrono::NaiveDateTime {
+        self.last_transaction_timestamp
+    }
+}
+
+impl CurrentTokenV2MetadataConvertible for ParquetCurrentTokenV2Metadata {
+    // TODO: consider returning a Result
+    fn from_base(base_item: CurrentTokenV2Metadata) -> Self {
+        Self {
+            object_address: base_item.object_address,
+            resource_type: base_item.resource_type,
+            data: canonical_json::to_string(&base_item.data).unwrap_or_else(|_| {
+                error!("Failed to serialize data to JSON: {:?}", base_item.data);
+                DEFAULT_NONE.to_string()
+            }),
+            state_key_hash: base_item.state_key_hash,
+            last_transaction_version: base_item.last_transaction_version,
+            last_transaction_timestamp: base_item.last_transaction_timestamp,
+        }
+    }
+}
+
+// Postgres Model
+
+#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(object_address, resource_type))]
+#[diesel(table_name = current_token_v2_metadata)]
+pub struct PostgresCurrentTokenV2Metadata {
+    pub object_address: String,
+    pub resource_type: String,
+    pub data: Value,
+    pub state_key_hash: String,
+    pub last_transaction_version: i64,
+}
+
+impl CurrentTokenV2MetadataConvertible for PostgresCurrentTokenV2Metadata {
+    fn from_base(base_item: CurrentTokenV2Metadata) -> Self {
+        Self {
+            object_address: base_item.object_address,
+            resource_type: base_item.resource_type,
+            data: base_item.data,
+            state_key_hash: base_item.state_key_hash,
+            last_transaction_version: base_item.last_transaction_version,
+        }
+    }
+}

--- a/processor/src/db/models/token_v2_models/v2_token_ownerships.rs
+++ b/processor/src/db/models/token_v2_models/v2_token_ownerships.rs
@@ -1,0 +1,887 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+#![allow(clippy::unused_unit)]
+
+use crate::{
+    bq_analytics::{GetTimeStamp, HasVersion, NamedTable},
+    db::{
+        models::{
+            object_models::v2_object_utils::{ObjectAggregatedDataMapping, ObjectWithMetadata},
+            token_models::{token_utils::TokenWriteSet, tokens::TableHandleToOwner},
+            token_v2_models::{
+                v2_token_datas::TokenDataV2,
+                v2_token_utils::{TokenStandard, TokenV2Burned, DEFAULT_OWNER_ADDRESS},
+            },
+            DEFAULT_NONE,
+        },
+        resources::FromWriteResource,
+    },
+    schema::{current_token_ownerships_v2, token_ownerships_v2},
+    utils::{
+        database::{DbContext, DbPoolConnection},
+        util::{ensure_not_negative, standardize_address},
+    },
+};
+use ahash::AHashMap;
+use allocative_derive::Allocative;
+use anyhow::Context;
+use aptos_protos::transaction::v1::{
+    DeleteResource, DeleteTableItem, WriteResource, WriteTableItem,
+};
+use bigdecimal::{BigDecimal, One, ToPrimitive, Zero};
+use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
+use field_count::FieldCount;
+use parquet_derive::ParquetRecordWriter;
+use serde::{Deserialize, Serialize};
+use tracing::error;
+
+// PK of current_token_ownerships_v2, i.e. token_data_id, property_version_v1, owner_address, storage_id
+pub type CurrentTokenOwnershipV2PK = (String, BigDecimal, String, String);
+
+#[derive(Clone, Debug, Deserialize, FieldCount, Serialize)]
+pub struct TokenOwnershipV2 {
+    pub transaction_version: i64,
+    pub write_set_change_index: i64,
+    pub token_data_id: String,
+    pub property_version_v1: BigDecimal,
+    pub owner_address: Option<String>,
+    pub storage_id: String,
+    pub amount: BigDecimal,
+    pub table_type_v1: Option<String>,
+    pub token_properties_mutated_v1: Option<serde_json::Value>,
+    pub is_soulbound_v2: Option<bool>,
+    pub token_standard: String,
+    pub is_fungible_v2: Option<bool>,
+    pub transaction_timestamp: chrono::NaiveDateTime,
+    pub non_transferrable_by_owner: Option<bool>,
+}
+
+pub trait TokenOwnershipV2Convertible {
+    fn from_base(base_item: TokenOwnershipV2) -> Self;
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CurrentTokenOwnershipV2 {
+    pub token_data_id: String,
+    pub property_version_v1: BigDecimal,
+    pub owner_address: String,
+    pub storage_id: String,
+    pub amount: BigDecimal,
+    pub table_type_v1: Option<String>,
+    pub token_properties_mutated_v1: Option<serde_json::Value>,
+    pub is_soulbound_v2: Option<bool>,
+    pub token_standard: String,
+    pub is_fungible_v2: Option<bool>,
+    pub last_transaction_version: i64,
+    pub last_transaction_timestamp: chrono::NaiveDateTime,
+    pub non_transferrable_by_owner: Option<bool>,
+}
+
+impl Ord for CurrentTokenOwnershipV2 {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.token_data_id
+            .cmp(&other.token_data_id)
+            .then(self.property_version_v1.cmp(&other.property_version_v1))
+            .then(self.owner_address.cmp(&other.owner_address))
+            .then(self.storage_id.cmp(&other.storage_id))
+    }
+}
+
+impl PartialOrd for CurrentTokenOwnershipV2 {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+pub trait CurrentTokenOwnershipV2Convertible {
+    fn from_base(base_item: CurrentTokenOwnershipV2) -> Self;
+}
+
+// Facilitate tracking when a token is burned
+#[derive(Clone, Debug)]
+pub struct NFTOwnershipV2 {
+    pub token_data_id: String,
+    pub owner_address: String,
+    pub is_soulbound: Option<bool>,
+}
+
+/// Need a separate struct for queryable because we don't want to define the inserted_at column (letting DB fill)
+#[derive(Clone, Debug, Queryable)]
+pub struct CurrentTokenOwnershipV2Query {
+    pub token_data_id: String,
+    pub property_version_v1: BigDecimal,
+    pub owner_address: String,
+    pub storage_id: String,
+    pub amount: BigDecimal,
+    pub table_type_v1: Option<String>,
+    pub token_properties_mutated_v1: Option<serde_json::Value>,
+    pub is_soulbound_v2: Option<bool>,
+    pub token_standard: String,
+    pub is_fungible_v2: Option<bool>,
+    pub last_transaction_version: i64,
+    pub last_transaction_timestamp: chrono::NaiveDateTime,
+    pub inserted_at: chrono::NaiveDateTime,
+    pub non_transferrable_by_owner: Option<bool>,
+}
+
+impl TokenOwnershipV2 {
+    /// For nfts it's the same resources that we parse tokendatas from so we leverage the work done in there to get ownership data
+    /// Vecs are returned because there could be multiple transfers in a single transaction and we need to document each one here.
+    pub fn get_nft_v2_from_token_data(
+        token_data: &TokenDataV2,
+        object_metadatas: &ObjectAggregatedDataMapping,
+    ) -> anyhow::Result<(
+        Vec<Self>,
+        AHashMap<CurrentTokenOwnershipV2PK, CurrentTokenOwnershipV2>,
+    )> {
+        let mut ownerships = vec![];
+        let mut current_ownerships = AHashMap::new();
+
+        let object_data = object_metadatas
+            .get(&token_data.token_data_id)
+            .context("If token data exists objectcore must exist")?;
+        let object_core = object_data.object.object_core.clone();
+        let token_data_id = token_data.token_data_id.clone();
+        let owner_address = object_core.get_owner_address();
+        let storage_id = token_data_id.clone();
+
+        // is_soulbound currently means if an object is completely untransferrable
+        // OR if only admin can transfer. Only the former is true soulbound but
+        // people might already be using it with the latter meaning so let's include both.
+        let is_soulbound = if object_data.untransferable.as_ref().is_some() {
+            true
+        } else {
+            !object_core.allow_ungated_transfer
+        };
+        let non_transferrable_by_owner = !object_core.allow_ungated_transfer;
+
+        ownerships.push(Self {
+            transaction_version: token_data.transaction_version,
+            write_set_change_index: token_data.write_set_change_index,
+            token_data_id: token_data_id.clone(),
+            property_version_v1: BigDecimal::zero(),
+            owner_address: Some(owner_address.clone()),
+            storage_id: storage_id.clone(),
+            amount: BigDecimal::one(),
+            table_type_v1: None,
+            token_properties_mutated_v1: None,
+            is_soulbound_v2: Some(is_soulbound),
+            token_standard: TokenStandard::V2.to_string(),
+            is_fungible_v2: None,
+            transaction_timestamp: token_data.transaction_timestamp,
+            non_transferrable_by_owner: Some(non_transferrable_by_owner),
+        });
+        current_ownerships.insert(
+            (
+                token_data_id.clone(),
+                BigDecimal::zero(),
+                owner_address.clone(),
+                storage_id.clone(),
+            ),
+            CurrentTokenOwnershipV2 {
+                token_data_id: token_data_id.clone(),
+                property_version_v1: BigDecimal::zero(),
+                owner_address,
+                storage_id: storage_id.clone(),
+                amount: BigDecimal::one(),
+                table_type_v1: None,
+                token_properties_mutated_v1: None,
+                is_soulbound_v2: Some(is_soulbound),
+                token_standard: TokenStandard::V2.to_string(),
+                is_fungible_v2: None,
+                last_transaction_version: token_data.transaction_version,
+                last_transaction_timestamp: token_data.transaction_timestamp,
+                non_transferrable_by_owner: Some(non_transferrable_by_owner),
+            },
+        );
+
+        // check if token was transferred
+        for (event_index, transfer_event) in &object_data.transfer_events {
+            // If it's a self transfer then skip
+            if transfer_event.get_to_address() == transfer_event.get_from_address() {
+                continue;
+            }
+            ownerships.push(Self {
+                transaction_version: token_data.transaction_version,
+                // set to negative of event index to avoid collison with write set index
+                write_set_change_index: -1 * event_index,
+                token_data_id: token_data_id.clone(),
+                property_version_v1: BigDecimal::zero(),
+                // previous owner
+                owner_address: Some(transfer_event.get_from_address()),
+                storage_id: storage_id.clone(),
+                // soft delete
+                amount: BigDecimal::zero(),
+                table_type_v1: None,
+                token_properties_mutated_v1: None,
+                is_soulbound_v2: Some(is_soulbound),
+                token_standard: TokenStandard::V2.to_string(),
+                is_fungible_v2: None,
+                transaction_timestamp: token_data.transaction_timestamp,
+                non_transferrable_by_owner: Some(is_soulbound),
+            });
+            current_ownerships.insert(
+                (
+                    token_data_id.clone(),
+                    BigDecimal::zero(),
+                    transfer_event.get_from_address(),
+                    storage_id.clone(),
+                ),
+                CurrentTokenOwnershipV2 {
+                    token_data_id: token_data_id.clone(),
+                    property_version_v1: BigDecimal::zero(),
+                    // previous owner
+                    owner_address: transfer_event.get_from_address(),
+                    storage_id: storage_id.clone(),
+                    // soft delete
+                    amount: BigDecimal::zero(),
+                    table_type_v1: None,
+                    token_properties_mutated_v1: None,
+                    is_soulbound_v2: Some(is_soulbound),
+                    token_standard: TokenStandard::V2.to_string(),
+                    is_fungible_v2: None,
+                    last_transaction_version: token_data.transaction_version,
+                    last_transaction_timestamp: token_data.transaction_timestamp,
+                    non_transferrable_by_owner: Some(is_soulbound),
+                },
+            );
+        }
+        Ok((ownerships, current_ownerships))
+    }
+
+    /// This handles the case where token is burned but objectCore is still there
+    pub async fn get_burned_nft_v2_from_write_resource(
+        write_resource: &WriteResource,
+        txn_version: i64,
+        write_set_change_index: i64,
+        txn_timestamp: chrono::NaiveDateTime,
+        prior_nft_ownership: &AHashMap<String, NFTOwnershipV2>,
+        tokens_burned: &TokenV2Burned,
+        object_metadatas: &ObjectAggregatedDataMapping,
+        db_context: &mut Option<DbContext<'_>>,
+    ) -> anyhow::Result<Option<(Self, CurrentTokenOwnershipV2)>> {
+        let token_data_id = standardize_address(&write_resource.address.to_string());
+        if tokens_burned
+            .get(&standardize_address(&token_data_id))
+            .is_some()
+        {
+            if let Some(object) = &ObjectWithMetadata::from_write_resource(write_resource)? {
+                let object_core = &object.object_core;
+                let owner_address = object_core.get_owner_address();
+                let storage_id = token_data_id.clone();
+
+                // is_soulbound currently means if an object is completely untransferrable
+                // OR if only admin can transfer. Only the former is true soulbound but
+                // people might already be using it with the latter meaning so let's include both.
+                let is_soulbound = if object_metadatas
+                    .get(&token_data_id)
+                    .map(|obj| obj.untransferable.as_ref())
+                    .is_some()
+                {
+                    true
+                } else {
+                    !object_core.allow_ungated_transfer
+                };
+                let non_transferrable_by_owner = !object_core.allow_ungated_transfer;
+
+                return Ok(Some((
+                    Self {
+                        transaction_version: txn_version,
+                        write_set_change_index,
+                        token_data_id: token_data_id.clone(),
+                        property_version_v1: BigDecimal::zero(),
+                        owner_address: Some(owner_address.clone()),
+                        storage_id: storage_id.clone(),
+                        amount: BigDecimal::zero(),
+                        table_type_v1: None,
+                        token_properties_mutated_v1: None,
+                        is_soulbound_v2: Some(is_soulbound),
+                        token_standard: TokenStandard::V2.to_string(),
+                        is_fungible_v2: Some(false),
+                        transaction_timestamp: txn_timestamp,
+                        non_transferrable_by_owner: Some(non_transferrable_by_owner),
+                    },
+                    CurrentTokenOwnershipV2 {
+                        token_data_id,
+                        property_version_v1: BigDecimal::zero(),
+                        owner_address,
+                        storage_id,
+                        amount: BigDecimal::zero(),
+                        table_type_v1: None,
+                        token_properties_mutated_v1: None,
+                        is_soulbound_v2: Some(is_soulbound),
+                        token_standard: TokenStandard::V2.to_string(),
+                        is_fungible_v2: Some(false),
+                        last_transaction_version: txn_version,
+                        last_transaction_timestamp: txn_timestamp,
+                        non_transferrable_by_owner: Some(non_transferrable_by_owner),
+                    },
+                )));
+            } else {
+                return Self::get_burned_nft_v2_helper(
+                    &token_data_id,
+                    txn_version,
+                    write_set_change_index,
+                    txn_timestamp,
+                    prior_nft_ownership,
+                    tokens_burned,
+                    db_context,
+                )
+                .await;
+            }
+        }
+        Ok(None)
+    }
+
+    /// This handles the case where token is burned and objectCore is deleted
+    pub async fn get_burned_nft_v2_from_delete_resource(
+        delete_resource: &DeleteResource,
+        txn_version: i64,
+        write_set_change_index: i64,
+        txn_timestamp: chrono::NaiveDateTime,
+        prior_nft_ownership: &AHashMap<String, NFTOwnershipV2>,
+        tokens_burned: &TokenV2Burned,
+        db_context: &mut Option<DbContext<'_>>,
+    ) -> anyhow::Result<Option<(Self, CurrentTokenOwnershipV2)>> {
+        let token_address = standardize_address(&delete_resource.address.to_string());
+        Self::get_burned_nft_v2_helper(
+            &token_address,
+            txn_version,
+            write_set_change_index,
+            txn_timestamp,
+            prior_nft_ownership,
+            tokens_burned,
+            db_context,
+        )
+        .await
+    }
+
+    async fn get_burned_nft_v2_helper(
+        token_address: &str,
+        txn_version: i64,
+        write_set_change_index: i64,
+        txn_timestamp: chrono::NaiveDateTime,
+        prior_nft_ownership: &AHashMap<String, NFTOwnershipV2>,
+        tokens_burned: &TokenV2Burned,
+        db_context: &mut Option<DbContext<'_>>,
+    ) -> anyhow::Result<Option<(Self, CurrentTokenOwnershipV2)>> {
+        let token_address = standardize_address(token_address);
+        if let Some(burn_event) = tokens_burned.get(&token_address) {
+            // 1. Try to lookup token address in burn event mapping
+            let previous_owner = if let Some(previous_owner) =
+                burn_event.get_previous_owner_address()
+            {
+                previous_owner
+            } else {
+                // 2. If it doesn't exist in burn event mapping, then it must be an old burn event that doesn't contain previous_owner.
+                // Do a lookup to get previous owner. This is necessary because previous owner is part of current token ownerships primary key.
+                match prior_nft_ownership.get(&token_address) {
+                    Some(inner) => inner.owner_address.clone(),
+                    None => {
+                        match db_context {
+                            None => {
+                                // TODO: update message
+                                tracing::error!(
+                                    transaction_version = txn_version,
+                                    lookup_key = &token_address,
+                                    "Failed to find current_token_ownership_v2 for burned token. You probably should backfill db."
+                                );
+                                DEFAULT_OWNER_ADDRESS.to_string()
+                            },
+                            Some(db_context) => {
+                                match CurrentTokenOwnershipV2Query::get_latest_owned_nft_by_token_data_id(
+                                    &mut db_context.conn,
+                                    &token_address,
+                                    db_context.query_retries,
+                                    db_context.query_retry_delay_ms,
+                                )
+                                    .await
+                                {
+                                    Ok(nft) => nft.owner_address.clone(),
+                                    Err(_) => {
+                                        tracing::error!(
+                                    transaction_version = txn_version,
+                                    lookup_key = &token_address,
+                                    "Failed to find current_token_ownership_v2 for burned token. You probably should backfill db."
+                                );
+                                        DEFAULT_OWNER_ADDRESS.to_string()
+                                    },
+                                }
+                            }
+                        }
+                    },
+                }
+            };
+
+            let token_data_id = token_address.clone();
+            let storage_id = token_data_id.clone();
+
+            return Ok(Some((
+                Self {
+                    transaction_version: txn_version,
+                    write_set_change_index,
+                    token_data_id: token_data_id.clone(),
+                    property_version_v1: BigDecimal::zero(),
+                    owner_address: Some(previous_owner.clone()),
+                    storage_id: storage_id.clone(),
+                    amount: BigDecimal::zero(),
+                    table_type_v1: None,
+                    token_properties_mutated_v1: None,
+                    is_soulbound_v2: None, // default
+                    token_standard: TokenStandard::V2.to_string(),
+                    is_fungible_v2: None, // default
+                    transaction_timestamp: txn_timestamp,
+                    non_transferrable_by_owner: None, // default
+                },
+                CurrentTokenOwnershipV2 {
+                    token_data_id,
+                    property_version_v1: BigDecimal::zero(),
+                    owner_address: previous_owner,
+                    storage_id,
+                    amount: BigDecimal::zero(),
+                    table_type_v1: None,
+                    token_properties_mutated_v1: None,
+                    is_soulbound_v2: None, // default
+                    token_standard: TokenStandard::V2.to_string(),
+                    is_fungible_v2: None, // default
+                    last_transaction_version: txn_version,
+                    last_transaction_timestamp: txn_timestamp,
+                    non_transferrable_by_owner: None, // default
+                },
+            )));
+        }
+        Ok(None)
+    }
+
+    /// We want to track tokens in any offer/claims and tokenstore
+    pub fn get_v1_from_write_table_item(
+        table_item: &WriteTableItem,
+        txn_version: i64,
+        write_set_change_index: i64,
+        txn_timestamp: chrono::NaiveDateTime,
+        table_handle_to_owner: &TableHandleToOwner,
+    ) -> anyhow::Result<Option<(Self, Option<CurrentTokenOwnershipV2>)>> {
+        let table_item_data = table_item.data.as_ref().unwrap();
+
+        let maybe_token = match TokenWriteSet::from_table_item_type(
+            table_item_data.value_type.as_str(),
+            &table_item_data.value,
+            txn_version,
+        )? {
+            Some(TokenWriteSet::Token(inner)) => Some(inner),
+            _ => None,
+        };
+
+        if let Some(token) = maybe_token {
+            let table_handle = standardize_address(&table_item.handle.to_string());
+            let amount = ensure_not_negative(token.amount);
+            let token_id_struct = token.id;
+            let token_data_id_struct = token_id_struct.token_data_id;
+            let token_data_id = token_data_id_struct.to_id();
+
+            let maybe_table_metadata = table_handle_to_owner.get(&table_handle);
+            let (curr_token_ownership, owner_address, table_type) = match maybe_table_metadata {
+                Some(tm) => {
+                    if tm.table_type != "0x3::token::TokenStore" {
+                        return Ok(None);
+                    }
+                    let owner_address = tm.get_owner_address();
+                    (
+                        Some(CurrentTokenOwnershipV2 {
+                            token_data_id: token_data_id.clone(),
+                            property_version_v1: token_id_struct.property_version.clone(),
+                            owner_address: owner_address.clone(),
+                            storage_id: table_handle.clone(),
+                            amount: amount.clone(),
+                            table_type_v1: Some(tm.table_type.clone()),
+                            token_properties_mutated_v1: Some(token.token_properties.clone()),
+                            is_soulbound_v2: None,
+                            token_standard: TokenStandard::V1.to_string(),
+                            is_fungible_v2: None,
+                            last_transaction_version: txn_version,
+                            last_transaction_timestamp: txn_timestamp,
+                            non_transferrable_by_owner: None,
+                        }),
+                        Some(owner_address),
+                        Some(tm.table_type.clone()),
+                    )
+                },
+                None => (None, None, None),
+            };
+
+            Ok(Some((
+                Self {
+                    transaction_version: txn_version,
+                    write_set_change_index,
+                    token_data_id,
+                    property_version_v1: token_id_struct.property_version,
+                    owner_address,
+                    storage_id: table_handle,
+                    amount,
+                    table_type_v1: table_type,
+                    token_properties_mutated_v1: Some(token.token_properties),
+                    is_soulbound_v2: None,
+                    token_standard: TokenStandard::V1.to_string(),
+                    is_fungible_v2: None,
+                    transaction_timestamp: txn_timestamp,
+                    non_transferrable_by_owner: None,
+                },
+                curr_token_ownership,
+            )))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// We want to track tokens in any offer/claims and tokenstore
+    pub fn get_v1_from_delete_table_item(
+        table_item: &DeleteTableItem,
+        txn_version: i64,
+        write_set_change_index: i64,
+        txn_timestamp: chrono::NaiveDateTime,
+        table_handle_to_owner: &TableHandleToOwner,
+    ) -> anyhow::Result<Option<(Self, Option<CurrentTokenOwnershipV2>)>> {
+        let table_item_data = table_item.data.as_ref().unwrap();
+
+        let maybe_token_id = match TokenWriteSet::from_table_item_type(
+            table_item_data.key_type.as_str(),
+            &table_item_data.key,
+            txn_version,
+        )? {
+            Some(TokenWriteSet::TokenId(inner)) => Some(inner),
+            _ => None,
+        };
+
+        if let Some(token_id_struct) = maybe_token_id {
+            let table_handle = standardize_address(&table_item.handle.to_string());
+            let token_data_id_struct = token_id_struct.token_data_id;
+            let token_data_id = token_data_id_struct.to_id();
+
+            let maybe_table_metadata = table_handle_to_owner.get(&table_handle);
+            let (curr_token_ownership, owner_address, table_type) = match maybe_table_metadata {
+                Some(tm) => {
+                    if tm.table_type != "0x3::token::TokenStore" {
+                        return Ok(None);
+                    }
+                    let owner_address = tm.get_owner_address();
+                    (
+                        Some(CurrentTokenOwnershipV2 {
+                            token_data_id: token_data_id.clone(),
+                            property_version_v1: token_id_struct.property_version.clone(),
+                            owner_address: owner_address.clone(),
+                            storage_id: table_handle.clone(),
+                            amount: BigDecimal::zero(),
+                            table_type_v1: Some(tm.table_type.clone()),
+                            token_properties_mutated_v1: None,
+                            is_soulbound_v2: None,
+                            token_standard: TokenStandard::V1.to_string(),
+                            is_fungible_v2: None,
+                            last_transaction_version: txn_version,
+                            last_transaction_timestamp: txn_timestamp,
+                            non_transferrable_by_owner: None,
+                        }),
+                        Some(owner_address),
+                        Some(tm.table_type.clone()),
+                    )
+                },
+                None => (None, None, None),
+            };
+
+            Ok(Some((
+                Self {
+                    transaction_version: txn_version,
+                    write_set_change_index,
+                    token_data_id,
+                    property_version_v1: token_id_struct.property_version,
+                    owner_address,
+                    storage_id: table_handle,
+                    amount: BigDecimal::zero(),
+                    table_type_v1: table_type,
+                    token_properties_mutated_v1: None,
+                    is_soulbound_v2: None,
+                    token_standard: TokenStandard::V1.to_string(),
+                    is_fungible_v2: None,
+                    transaction_timestamp: txn_timestamp,
+                    non_transferrable_by_owner: None,
+                },
+                curr_token_ownership,
+            )))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl CurrentTokenOwnershipV2Query {
+    pub async fn get_latest_owned_nft_by_token_data_id(
+        conn: &mut DbPoolConnection<'_>,
+        token_data_id: &str,
+        query_retries: u32,
+        query_retry_delay_ms: u64,
+    ) -> anyhow::Result<NFTOwnershipV2> {
+        let mut tried = 0;
+        while tried < query_retries {
+            tried += 1;
+            match Self::get_latest_owned_nft_by_token_data_id_impl(conn, token_data_id).await {
+                Ok(inner) => {
+                    return Ok(NFTOwnershipV2 {
+                        token_data_id: inner.token_data_id.clone(),
+                        owner_address: inner.owner_address.clone(),
+                        is_soulbound: inner.is_soulbound_v2,
+                    });
+                },
+                Err(_) => {
+                    if tried < query_retries {
+                        tokio::time::sleep(std::time::Duration::from_millis(query_retry_delay_ms))
+                            .await;
+                    }
+                },
+            }
+        }
+        Err(anyhow::anyhow!(
+            "Failed to get nft by token data id: {}",
+            token_data_id
+        ))
+    }
+
+    async fn get_latest_owned_nft_by_token_data_id_impl(
+        conn: &mut DbPoolConnection<'_>,
+        token_data_id: &str,
+    ) -> diesel::QueryResult<Self> {
+        current_token_ownerships_v2::table
+            .filter(current_token_ownerships_v2::token_data_id.eq(token_data_id))
+            .filter(current_token_ownerships_v2::amount.gt(BigDecimal::zero()))
+            .first::<Self>(conn)
+            .await
+    }
+}
+
+// Parquet Model
+
+#[derive(
+    Allocative, Clone, Debug, Default, Deserialize, FieldCount, ParquetRecordWriter, Serialize,
+)]
+pub struct ParquetTokenOwnershipV2 {
+    pub txn_version: i64,
+    pub write_set_change_index: i64,
+    pub token_data_id: String,
+    pub property_version_v1: u64,
+    pub owner_address: Option<String>,
+    pub storage_id: String,
+    pub amount: String, // this is a string representation of a bigdecimal
+    pub table_type_v1: Option<String>,
+    pub token_properties_mutated_v1: Option<String>,
+    pub is_soulbound_v2: Option<bool>,
+    pub token_standard: String,
+    #[allocative(skip)]
+    pub block_timestamp: chrono::NaiveDateTime,
+    pub non_transferrable_by_owner: Option<bool>,
+}
+
+impl NamedTable for ParquetTokenOwnershipV2 {
+    const TABLE_NAME: &'static str = "token_ownerships_v2";
+}
+
+impl HasVersion for ParquetTokenOwnershipV2 {
+    fn version(&self) -> i64 {
+        self.txn_version
+    }
+}
+
+impl GetTimeStamp for ParquetTokenOwnershipV2 {
+    fn get_timestamp(&self) -> chrono::NaiveDateTime {
+        self.block_timestamp
+    }
+}
+
+impl TokenOwnershipV2Convertible for ParquetTokenOwnershipV2 {
+    fn from_base(base_item: TokenOwnershipV2) -> Self {
+        Self {
+            txn_version: base_item.transaction_version,
+            write_set_change_index: base_item.write_set_change_index,
+            token_data_id: base_item.token_data_id,
+            property_version_v1: base_item.property_version_v1.to_u64().unwrap(),
+            owner_address: base_item.owner_address,
+            storage_id: base_item.storage_id,
+            amount: base_item.amount.to_string(),
+            table_type_v1: base_item.table_type_v1,
+            token_properties_mutated_v1: base_item
+                .token_properties_mutated_v1
+                .map(|v| v.to_string()),
+            is_soulbound_v2: base_item.is_soulbound_v2,
+            token_standard: base_item.token_standard,
+            block_timestamp: base_item.transaction_timestamp,
+            non_transferrable_by_owner: base_item.non_transferrable_by_owner,
+        }
+    }
+}
+
+#[derive(
+    Allocative, Clone, Debug, Default, Deserialize, FieldCount, ParquetRecordWriter, Serialize,
+)]
+pub struct ParquetCurrentTokenOwnershipV2 {
+    pub token_data_id: String,
+    pub property_version_v1: u64, // BigDecimal,
+    pub owner_address: String,
+    pub storage_id: String,
+    pub amount: String, // BigDecimal,
+    pub table_type_v1: Option<String>,
+    pub token_properties_mutated_v1: Option<String>, // Option<serde_json::Value>,
+    pub is_soulbound_v2: Option<bool>,
+    pub token_standard: String,
+    pub is_fungible_v2: Option<bool>,
+    pub last_transaction_version: i64,
+    #[allocative(skip)]
+    pub last_transaction_timestamp: chrono::NaiveDateTime,
+    pub non_transferrable_by_owner: Option<bool>,
+}
+
+impl NamedTable for ParquetCurrentTokenOwnershipV2 {
+    const TABLE_NAME: &'static str = "current_token_ownerships_v2";
+}
+
+impl HasVersion for ParquetCurrentTokenOwnershipV2 {
+    fn version(&self) -> i64 {
+        self.last_transaction_version
+    }
+}
+
+impl GetTimeStamp for ParquetCurrentTokenOwnershipV2 {
+    fn get_timestamp(&self) -> chrono::NaiveDateTime {
+        self.last_transaction_timestamp
+    }
+}
+
+// Facilitate tracking when a token is burned
+impl CurrentTokenOwnershipV2Convertible for ParquetCurrentTokenOwnershipV2 {
+    fn from_base(base_item: CurrentTokenOwnershipV2) -> Self {
+        Self {
+            token_data_id: base_item.token_data_id,
+            property_version_v1: base_item.property_version_v1.to_u64().unwrap(),
+            owner_address: base_item.owner_address,
+            storage_id: base_item.storage_id,
+            amount: base_item.amount.to_string(),
+            table_type_v1: base_item.table_type_v1,
+            token_properties_mutated_v1: base_item
+                .token_properties_mutated_v1
+                .and_then(|v| {
+                    canonical_json::to_string(&v)
+                        .map_err(|e| {
+                            error!("Failed to convert token_properties_mutated_v1: {:?}", e);
+                            e
+                        })
+                        .ok()
+                })
+                .or_else(|| Some(DEFAULT_NONE.to_string())),
+            is_soulbound_v2: base_item.is_soulbound_v2,
+            token_standard: base_item.token_standard,
+            is_fungible_v2: base_item.is_fungible_v2,
+            last_transaction_version: base_item.last_transaction_version,
+            last_transaction_timestamp: base_item.last_transaction_timestamp,
+            non_transferrable_by_owner: base_item.non_transferrable_by_owner,
+        }
+    }
+}
+
+// Postgres Model
+
+#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(transaction_version, write_set_change_index))]
+#[diesel(table_name = token_ownerships_v2)]
+pub struct PostgresTokenOwnershipV2 {
+    pub transaction_version: i64,
+    pub write_set_change_index: i64,
+    pub token_data_id: String,
+    pub property_version_v1: BigDecimal,
+    pub owner_address: Option<String>,
+    pub storage_id: String,
+    pub amount: BigDecimal,
+    pub table_type_v1: Option<String>,
+    pub token_properties_mutated_v1: Option<serde_json::Value>,
+    pub is_soulbound_v2: Option<bool>,
+    pub token_standard: String,
+    pub is_fungible_v2: Option<bool>,
+    pub transaction_timestamp: chrono::NaiveDateTime,
+    pub non_transferrable_by_owner: Option<bool>,
+}
+
+impl TokenOwnershipV2Convertible for PostgresTokenOwnershipV2 {
+    fn from_base(base_item: TokenOwnershipV2) -> Self {
+        Self {
+            transaction_version: base_item.transaction_version,
+            write_set_change_index: base_item.write_set_change_index,
+            token_data_id: base_item.token_data_id,
+            property_version_v1: base_item.property_version_v1,
+            owner_address: base_item.owner_address,
+            storage_id: base_item.storage_id,
+            amount: base_item.amount,
+            table_type_v1: base_item.table_type_v1,
+            token_properties_mutated_v1: base_item.token_properties_mutated_v1,
+            is_soulbound_v2: base_item.is_soulbound_v2,
+            token_standard: base_item.token_standard,
+            is_fungible_v2: base_item.is_fungible_v2,
+            transaction_timestamp: base_item.transaction_timestamp,
+            non_transferrable_by_owner: base_item.non_transferrable_by_owner,
+        }
+    }
+}
+#[derive(
+    Clone, Debug, Deserialize, Eq, FieldCount, Identifiable, Insertable, PartialEq, Serialize,
+)]
+#[diesel(primary_key(token_data_id, property_version_v1, owner_address, storage_id))]
+#[diesel(table_name = current_token_ownerships_v2)]
+pub struct PostgresCurrentTokenOwnershipV2 {
+    pub token_data_id: String,
+    pub property_version_v1: BigDecimal,
+    pub owner_address: String,
+    pub storage_id: String,
+    pub amount: BigDecimal,
+    pub table_type_v1: Option<String>,
+    pub token_properties_mutated_v1: Option<serde_json::Value>,
+    pub is_soulbound_v2: Option<bool>,
+    pub token_standard: String,
+    pub is_fungible_v2: Option<bool>,
+    pub last_transaction_version: i64,
+    pub last_transaction_timestamp: chrono::NaiveDateTime,
+    pub non_transferrable_by_owner: Option<bool>,
+}
+
+impl Ord for PostgresCurrentTokenOwnershipV2 {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.token_data_id
+            .cmp(&other.token_data_id)
+            .then(self.property_version_v1.cmp(&other.property_version_v1))
+            .then(self.owner_address.cmp(&other.owner_address))
+            .then(self.storage_id.cmp(&other.storage_id))
+    }
+}
+
+impl PartialOrd for PostgresCurrentTokenOwnershipV2 {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl CurrentTokenOwnershipV2Convertible for PostgresCurrentTokenOwnershipV2 {
+    fn from_base(base_item: CurrentTokenOwnershipV2) -> Self {
+        Self {
+            token_data_id: base_item.token_data_id,
+            property_version_v1: base_item.property_version_v1,
+            owner_address: base_item.owner_address,
+            storage_id: base_item.storage_id,
+            amount: base_item.amount,
+            table_type_v1: base_item.table_type_v1,
+            token_properties_mutated_v1: base_item.token_properties_mutated_v1,
+            is_soulbound_v2: base_item.is_soulbound_v2,
+            token_standard: base_item.token_standard,
+            is_fungible_v2: base_item.is_fungible_v2,
+            last_transaction_version: base_item.last_transaction_version,
+            last_transaction_timestamp: base_item.last_transaction_timestamp,
+            non_transferrable_by_owner: base_item.non_transferrable_by_owner,
+        }
+    }
+}


### PR DESCRIPTION
### Description
1. Moved all token_v2 models and some of dependent V1 models
2. added deprecating Token V1 as TODOs in the list. https://www.notion.so/aptoslabs/Refactor-processors-folders-18a8b846eb7280c2b037f302d31d1f22?pvs=4