### PR TITLE
refcator move_modules

### DIFF
--- a/processor/src/db/models/default_models/mod.rs
+++ b/processor/src/db/models/default_models/mod.rs
@@ -1,6 +1,6 @@
 pub mod block_metadata_transactions;
+pub mod move_modules;
 pub mod move_resources;
-pub mod parquet_move_modules;
 pub mod parquet_transactions;
 pub mod parquet_write_set_changes;
 pub mod table_items;

--- a/processor/src/db/models/default_models/parquet_write_set_changes.rs
+++ b/processor/src/db/models/default_models/parquet_write_set_changes.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::extra_unused_lifetimes)]
 
 use super::{
-    parquet_move_modules::MoveModule,
+    move_modules::MoveModule,
     table_items::{
         ParquetCurrentTableItem, ParquetTableItem, ParquetTableMetadata, TableItem, TableMetadata,
     },


### PR DESCRIPTION
### Description
Split `MoveModule` into base and parquet models and moved implementation of parsing logic to base model and impl "From<T>`  to convert Base to Parquet for type-conversion. 

### What changed?
* Renamed `parquet_move_modules.rs` to `move_modules.rs`
* Created a base `MoveModule` struct without parquet-specific traits
* Renamed existing `MoveModule` struct into  `ParquetMoveModule`  with parquet-specific traits implementations.
  * Removed unnecessary trait implementation from parquet `MoveModule`
* Added conversion from `MoveModule` to `ParquetMoveModule`

### Why make this change?
This separation provides a clearer distinction between base data models and their parquet-specific implementations, making the code more maintainable and easier to understand. It also allows for future flexibility in how move modules are handled without being tightly coupled to parquet-specific functionality.