### PR TITLE
refcator transactions

### DIFF
--- a/processor/src/db/models/default_models/mod.rs
+++ b/processor/src/db/models/default_models/mod.rs
@@ -1,6 +1,6 @@
 pub mod block_metadata_transactions;
 pub mod move_modules;
 pub mod move_resources;
-pub mod parquet_transactions;
 pub mod parquet_write_set_changes;
 pub mod table_items;
+pub mod transactions;


### PR DESCRIPTION
### Description
Split the Transaction model into two separate structs: a base Transaction and a ParquetTransaction

### What changed?
- Renamed `parquet_transactions.rs` to `transactions.rs`
- Created a new `ParquetTransaction` struct that implements Parquet-specific traits
- Simplified the base `Transaction` struct by removing Parquet-related implementations
- Moved Parquet-specific traits and implementations to the new `ParquetTransaction` struct
- Removed unused `GetTimeStamp` implementation

### Why make this change?
This change separates concerns between basic transaction handling and Parquet-specific functionality, making the code more modular and easier to maintain. It allows the base Transaction struct to be used in contexts where Parquet functionality isn't needed.