### PR TITLE
refactor write set changes

### DIFF
--- a/processor/src/db/models/default_models/mod.rs
+++ b/processor/src/db/models/default_models/mod.rs
@@ -1,6 +1,6 @@
 pub mod block_metadata_transactions;
 pub mod move_modules;
 pub mod move_resources;
-pub mod parquet_write_set_changes;
 pub mod table_items;
 pub mod transactions;
+pub mod write_set_changes;

--- a/processor/src/db/models/default_models/transactions.rs
+++ b/processor/src/db/models/default_models/transactions.rs
@@ -5,7 +5,7 @@
 #![allow(clippy::extra_unused_lifetimes)]
 #![allow(clippy::unused_unit)]
 
-use super::parquet_write_set_changes::{WriteSetChangeDetail, WriteSetChangeModel};
+use super::write_set_changes::{WriteSetChangeDetail, WriteSetChangeModel};
 use crate::{
     bq_analytics::{HasVersion, NamedTable},
     utils::{


### PR DESCRIPTION
### Description
Split the WriteSetChange model into two separate structs: a base Transaction and a ParquetTransaction
[](url)
### What changed?
- Renamed `parquet_write_set_changes.rs` to `write_set_changes.rs`
- Created a new `ParquetWriteSetChange` struct specifically for Parquet operations
- Removed Parquet-specific traits from the base `WriteSetChange` model
- Added a conversion implementation from `WriteSetChange` to `ParquetWriteSetChange`
- Updated related imports and references

### How to test?
1. Verify that existing Parquet write operations continue to work
2. Ensure the conversion between `WriteSetChange` and `ParquetWriteSetChange` maintains data integrity
3. Confirm that all existing functionality using write set changes remains unaffected

### Why make this change?
This change creates a clear separation between the base write set change model and its Parquet-specific implementation, making the code more maintainable and allowing for different implementations without modifying the base model. This separation of concerns will make it easier to add new storage formats in the future.