### PR TITLE
migrate testing workflows

### DIFF
--- a/.github/actions/dep_install_and_lint/action.yaml
+++ b/.github/actions/dep_install_and_lint/action.yaml
@@ -1,0 +1,28 @@
+name: "Install Dependencies and Run Linter"
+description: "Installs dependencies and runs the Rust linter."
+
+inputs:
+  working-directory:
+    description: 'The working directory for the linter'
+    required: true
+    default: '.'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Dependencies
+      run: |
+        sudo apt update && sudo apt install libdw-dev
+        cargo install cargo-sort
+        rustup update
+        rustup toolchain install nightly
+        rustup component add clippy --toolchain nightly
+        rustup component add rustfmt --toolchain nightly
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+
+    - name: Run Linter
+      run: |
+        scripts/rust_lint.sh --check
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}

--- a/.github/actions/rust-setup/action.yaml
+++ b/.github/actions/rust-setup/action.yaml
@@ -1,0 +1,25 @@
+name: "Rust setup"
+description: |
+  Runs an opinionated and unified Rust setup action. It does the following:
+  * Installs deps for Rust
+  * Installs the Rust toolchain
+  * Sets up the cargo cache
+
+runs:
+  using: composite
+  steps:
+    - run: sudo apt-get update && sudo apt-get install build-essential ca-certificates clang curl git libpq-dev libssl-dev pkg-config lsof lld libdw-dev --no-install-recommends --assume-yes
+      shell: bash
+
+    - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
+      with:
+        override: true
+        components: rustfmt, clippy
+
+    # rust-cache action will cache ~/.cargo and ./target
+    # https://github.com/Swatinem/rust-cache#cache-details
+    - name: Run cargo cache
+      uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # pin@v2.2.0
+
+    - run: echo "/home/runner/.cargo/bin" | tee -a $GITHUB_PATH
+      shell: bash

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,0 +1,110 @@
+name: Run Integration Tests
+run-name: Run Integration Tests for commit ${{ github.event.client_payload.commit_hash || github.event.inputs.commit_hash || 'main' }} by @${{ github.actor }}
+on:
+  repository_dispatch:
+    types: [test-txn-json-change-detected]  # Custom event type to trigger the workflow
+
+  workflow_dispatch:
+    inputs:
+      commit_hash:
+        description: 'Commit hash to use for the dependency update'
+        required: true
+        default: 'main'
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  Integration-tests:
+    runs-on: runs-on,runner=2cpu-linux-x64,run-id=${{ github.run_id }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }} # check out the code from the pull request branch:
+
+      # Install toml-cli using cargo
+      - name: Install toml-cli
+        run: cargo install toml-cli
+
+      # Show Cargo.toml Before Update
+      - name: Show Cargo.toml Before Update
+        run: cat Cargo.toml
+
+      # Update aptos-system-utils dependency using toml-cli
+      - name: Update aptos-system-utils dependency
+        if: ${{ github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' }}
+        run: |
+          COMMIT_HASH=${{ github.event.client_payload.commit_hash || github.event.inputs.commit_hash }}
+          echo "Updating aptos-system-utils dependency in Cargo.toml to use commit hash $COMMIT_HASH"
+          toml set Cargo.toml workspace.dependencies.aptos-system-utils.rev "$COMMIT_HASH" > Cargo.tmp && mv Cargo.tmp Cargo.toml
+
+      # Update aptos-indexer-test-transactions dependency using toml-cli
+      - name: Update aptos-indexer-test-transactions dependency
+        if: ${{ github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' }}
+        run: |
+          COMMIT_HASH=${{ github.event.client_payload.commit_hash || github.event.inputs.commit_hash }}
+
+          echo "Updating aptos-indexer-test-transactions dependency in Cargo.toml to use commit hash $COMMIT_HASH"
+          toml set Cargo.toml workspace.dependencies.aptos-indexer-test-transactions.rev "$COMMIT_HASH" > Cargo.tmp && mv Cargo.tmp Cargo.toml
+
+      # Show Cargo.toml after the update
+      - name: Show Cargo.toml After Update
+        run: cat Cargo.toml  # Correct path to the Cargo.toml file
+          
+      # Ensure Cargo.lock is updated with the latest dependencies
+      - name: rust setup
+        run: |
+          sudo apt update && sudo apt install libdw-dev
+          cargo update
+        working-directory: .
+
+      # Cache Cargo
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          
+      # Run Integration Tests
+      - name: Run Integration Tests
+        id: tests
+        run: |
+          # TODO: until we have more comprehensive cli parsers, we will need to run tests separately.
+          cargo test sdk_tests -- --nocapture
+        working-directory: integration-tests
+
+      # Run all Tests
+      - name: Run Sanity Tests
+        id: sanity-check
+        continue-on-error: true
+        run: |
+          cargo test regression_tests -- --nocapture
+        working-directory: integration-tests
+      
+      - name: Fail if tests fail
+        if: ${{ steps.sanity-check.outcome == 'failure' && github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'indexer-sdk-update') }}
+        run: |
+          echo "Integration failed"
+          exit 1
+
+      - name: Send Slack Notification to oncall
+        if: ${{ steps.sanity-check.outcome == 'failure' && github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'indexer-sdk-update') }}
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          # eco-infra-oncall channel.
+          channel-id: 'C0468USBLQJ'
+          slack-message: |
+            :warning: Tests failed on PR with indexer-sdk-update label
+            PR: ${{ github.event.pull_request.html_url }}
+            Author: ${{ github.event.pull_request.user.login }}
+            Title: ${{ github.event.pull_request.title }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/nightly-integration-tests.yaml
+++ b/.github/workflows/nightly-integration-tests.yaml
@@ -1,0 +1,24 @@
+name: "Nightly Run Integration Tests"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 9 * * *'  # This runs the workflow every day at 9:00 AM UTC
+
+jobs:
+
+  nightly-run:
+    runs-on: runs-on,runner=2cpu-linux-x64,run-id=${{ github.run_id }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Dependencies and Run Linter
+        uses: ./.github/actions/dep_install_and_lint
+        with:
+          working-directory: .
+
+      - name: Run Integration Tests
+        run: cargo test --manifest-path integration-tests/Cargo.toml
+        working-directory: .


### PR DESCRIPTION
### TL;DR
Moved GitHub Actions workflows for running integration tests and nightly builds, along with reusable actions for Rust setup and dependency installation.

### What changed?
- Migrated GitHub workflow for integration tests that:' label
- Migrated nightly integration test workflow that runs daily at 9:00 AM UTC
- Migrated reusable actions for:
  - Rust setup (installing toolchain and dependencies)
  - Installing dependencies and running linter
