### PR TITLE
migrate parquet user transaction processor

### DIFF
--- a/processor/src/config/indexer_processor_config.rs
+++ b/processor/src/config/indexer_processor_config.rs
@@ -3,7 +3,10 @@
 
 use super::{db_config::DbConfig, processor_config::ProcessorConfig};
 use crate::{
-    parquet_processors::parquet_default_processor::ParquetDefaultProcessor,
+    parquet_processors::{
+        parquet_default_processor::ParquetDefaultProcessor,
+        parquet_user_transaction_processor::ParquetUserTransactionProcessor,
+    },
     processors::{
         account_transactions_processor::AccountTransactionsProcessor, ans_processor::AnsProcessor,
         default_processor::DefaultProcessor, events_processor::EventsProcessor,
@@ -86,11 +89,11 @@ impl RunnableConfig for IndexerProcessorConfig {
             //     let parquet_events_processor = ParquetEventsProcessor::new(self.clone()).await?;
             //     parquet_events_processor.run_processor().await
             // },
-            // ProcessorConfig::ParquetUserTransactionsProcessor(_) => {
-            //     let parquet_user_transactions_processor =
-            //         ParquetUserTransactionsProcessor::new(self.clone()).await?;
-            //     parquet_user_transactions_processor.run_processor().await
-            // },
+            ProcessorConfig::ParquetUserTransactionProcessor(_) => {
+                let parquet_user_transaction_processor =
+                    ParquetUserTransactionProcessor::new(self.clone()).await?;
+                parquet_user_transaction_processor.run_processor().await
+            },
             // ProcessorConfig::ParquetFungibleAssetProcessor(_) => {
             //     let parquet_fungible_asset_processor =
             //         ParquetFungibleAssetProcessor::new(self.clone()).await?;

--- a/processor/src/config/processor_config.rs
+++ b/processor/src/config/processor_config.rs
@@ -42,7 +42,7 @@ use crate::{
         //     v2_token_ownerships::{CurrentTokenOwnershipV2, TokenOwnershipV2},
         // },
         // transaction_metadata_model::write_set_size_info::WriteSetSize,
-        // user_transaction_models::user_transactions::UserTransaction,
+        user_transaction_models::user_transactions::ParquetUserTransaction,
     },
     processors::ans_processor::AnsProcessorConfig,
     processors::token_v2_processor::TokenV2ProcessorConfig,
@@ -108,13 +108,13 @@ pub enum ProcessorConfig {
     ParquetDefaultProcessor(ParquetDefaultProcessorConfig),
     // ParquetEventsProcessor(ParquetDefaultProcessorConfig), // TODO: Add this back when we migrate the processor
     // ParquetAnsProcessor(ParquetAnsProcessorConfig), // TODO: Add this back when we migrate the processor
-    // ParquetUserTransactionsProcessor(ParquetDefaultProcessorConfig), // TODO: Add this back when we migrate the processor
-    // ParquetFungibleAssetProcessor(ParquetDefaultProcessorConfig), // TODO: Add this back when we migrate the processor
-    // ParquetTransactionMetadataProcessor(ParquetDefaultProcessorConfig), // TODO: Add this back when we migrate the processor
-    // ParquetAccountTransactionsProcessor(ParquetDefaultProcessorConfig), // TODO: Add this back when we migrate the processor
-    // ParquetTokenV2Processor(ParquetDefaultProcessorConfig), // TODO: Add this back when we migrate the processor
-    // ParquetStakeProcessor(ParquetDefaultProcessorConfig), // TODO: Add this back when we migrate the processor
-    // ParquetObjectsProcessor(ParquetDefaultProcessorConfig), // TODO: Add this back when we migrate the processor
+    ParquetUserTransactionProcessor(ParquetDefaultProcessorConfig), // TODO: Add this back when we migrate the processor
+                                                                    // ParquetFungibleAssetProcessor(ParquetDefaultProcessorConfig), // TODO: Add this back when we migrate the processor
+                                                                    // ParquetTransactionMetadataProcessor(ParquetDefaultProcessorConfig), // TODO: Add this back when we migrate the processor
+                                                                    // ParquetAccountTransactionsProcessor(ParquetDefaultProcessorConfig), // TODO: Add this back when we migrate the processor
+                                                                    // ParquetTokenV2Processor(ParquetDefaultProcessorConfig), // TODO: Add this back when we migrate the processor
+                                                                    // ParquetStakeProcessor(ParquetDefaultProcessorConfig), // TODO: Add this back when we migrate the processor
+                                                                    // ParquetObjectsProcessor(ParquetDefaultProcessorConfig), // TODO: Add this back when we migrate the processor
 }
 
 impl ProcessorConfig {
@@ -131,15 +131,15 @@ impl ProcessorConfig {
     /// is useful for querying the status from the processor status table in the database.
     pub fn get_processor_status_table_names(&self) -> anyhow::Result<Vec<String>> {
         let default_config = match self {
-            ProcessorConfig::ParquetDefaultProcessor(config) => config,
+            ProcessorConfig::ParquetDefaultProcessor(config)
             // | ProcessorConfig::ParquetEventsProcessor(config)
-            // | ProcessorConfig::ParquetUserTransactionsProcessor(config)
             // | ProcessorConfig::ParquetTransactionMetadataProcessor(config)
             // | ProcessorConfig::ParquetAccountTransactionsProcessor(config)
             // | ProcessorConfig::ParquetTokenV2Processor(config)
             // | ProcessorConfig::ParquetStakeProcessor(config)
             // | ProcessorConfig::ParquetObjectsProcessor(config)
-            // | ProcessorConfig::ParquetFungibleAssetProcessor(config) => &config,
+            // | ProcessorConfig::ParquetFungibleAssetProcessor(config)
+            | ProcessorConfig::ParquetUserTransactionProcessor(config) => config,
             // | ProcessorConfig::ParquetAnsProcessor(config) => &config.default,
             _ => {
                 return Err(anyhow::anyhow!(
@@ -191,9 +191,9 @@ impl ProcessorConfig {
             //     CurrentAnsLookupV2::TABLE_NAME.to_string(),
             //     CurrentAnsPrimaryNameV2::TABLE_NAME.to_string(),
             // ]),
-            // ProcessorName::ParquetUserTransactionsProcessor => {
-            //     HashSet::from([UserTransaction::TABLE_NAME.to_string()])
-            // },
+            ProcessorName::ParquetUserTransactionProcessor => {
+                HashSet::from([ParquetUserTransaction::TABLE_NAME.to_string()])
+            },
             // ProcessorName::ParquetFungibleAssetProcessor => HashSet::from([
             //     FungibleAssetActivity::TABLE_NAME.to_string(),
             //     FungibleAssetBalance::TABLE_NAME.to_string(),

--- a/processor/src/parquet_processors/mod.rs
+++ b/processor/src/parquet_processors/mod.rs
@@ -46,7 +46,7 @@ use crate::{
         //     v2_token_ownerships::{CurrentTokenOwnershipV2, TokenOwnershipV2},
         // },
         // transaction_metadata_model::parquet_write_set_size_info::WriteSetSize,
-        // user_transaction_models::parquet_user_transactions::UserTransaction,
+        user_transaction_models::user_transactions::ParquetUserTransaction,
     },
     utils::table_flags::TableFlags,
 };
@@ -73,7 +73,7 @@ pub mod parquet_default_processor;
 // pub mod parquet_stake_processor;
 // pub mod parquet_token_v2_processor;
 // pub mod parquet_transaction_metadata_processor;
-// pub mod parquet_user_transaction_processor;
+pub mod parquet_user_transaction_processor;
 
 const GOOGLE_APPLICATION_CREDENTIALS: &str = "GOOGLE_APPLICATION_CREDENTIALS";
 
@@ -111,8 +111,8 @@ pub enum ParquetTypeEnum {
     TableMetadata,
     // // events
     // Events,
-    // // user transactions
-    // UserTransactions,
+    // user transactions
+    UserTransactions,
     // // ANS types
     // AnsPrimaryNameV2,
     // CurrentAnsPrimaryNameV2,
@@ -202,7 +202,7 @@ impl_parquet_trait!(
 );
 impl_parquet_trait!(ParquetTableMetadata, ParquetTypeEnum::TableMetadata);
 // impl_parquet_trait!(EventPQ, ParquetTypeEnum::Events);
-// impl_parquet_trait!(UserTransaction, ParquetTypeEnum::UserTransactions);
+impl_parquet_trait!(ParquetUserTransaction, ParquetTypeEnum::UserTransactions);
 // impl_parquet_trait!(AnsPrimaryNameV2, ParquetTypeEnum::AnsPrimaryNameV2);
 // impl_parquet_trait!(
 //     FungibleAssetActivity,
@@ -276,8 +276,8 @@ pub enum ParquetTypeStructs {
     TableMetadata(Vec<ParquetTableMetadata>),
     // // Events
     // Event(Vec<EventPQ>),
-    // // User txn
-    // UserTransaction(Vec<UserTransaction>),
+    // User txn
+    UserTransaction(Vec<ParquetUserTransaction>),
     // // ANS types
     // AnsPrimaryNameV2(Vec<AnsPrimaryNameV2>),
     // CurrentAnsPrimaryNameV2(Vec<CurrentAnsPrimaryNameV2>),
@@ -326,7 +326,7 @@ impl ParquetTypeStructs {
             },
             ParquetTypeEnum::TableMetadata => ParquetTypeStructs::TableMetadata(Vec::new()),
             // ParquetTypeEnum::Events => ParquetTypeStructs::Event(Vec::new()),
-            // ParquetTypeEnum::UserTransactions => ParquetTypeStructs::UserTransaction(Vec::new()),
+            ParquetTypeEnum::UserTransactions => ParquetTypeStructs::UserTransaction(Vec::new()),
             // ParquetTypeEnum::AnsPrimaryNameV2 => ParquetTypeStructs::AnsPrimaryNameV2(Vec::new()),
             // ParquetTypeEnum::FungibleAssetActivities => {
             //     ParquetTypeStructs::FungibleAssetActivity(Vec::new())
@@ -446,12 +446,12 @@ impl ParquetTypeStructs {
             ) => {
                 handle_append!(self_data, other_data)
             },
-            // (
-            //     ParquetTypeStructs::UserTransaction(self_data),
-            //     ParquetTypeStructs::UserTransaction(other_data),
-            // ) => {
-            //     handle_append!(self_data, other_data)
-            // },
+            (
+                ParquetTypeStructs::UserTransaction(self_data),
+                ParquetTypeStructs::UserTransaction(other_data),
+            ) => {
+                handle_append!(self_data, other_data)
+            },
             // (
             //     ParquetTypeStructs::FungibleAssetActivity(self_data),
             //     ParquetTypeStructs::FungibleAssetActivity(other_data),

--- a/processor/src/parquet_processors/parquet_user_transaction_processor.rs
+++ b/processor/src/parquet_processors/parquet_user_transaction_processor.rs
@@ -1,0 +1,180 @@
+use crate::{
+    config::{
+        db_config::DbConfig, indexer_processor_config::IndexerProcessorConfig,
+        processor_config::ProcessorConfig,
+    },
+    parquet_processors::{
+        initialize_database_pool, initialize_gcs_client, initialize_parquet_buffer_step,
+        set_backfill_table_flag, ParquetTypeEnum,
+    },
+    steps::{
+        common::{
+            parquet_version_tracker_step::ParquetVersionTrackerStep,
+            processor_status_saver::get_processor_status_saver,
+        },
+        parquet_processor_steps::parquet_user_transaction_processor::parquet_user_transaction_extractor::ParquetUserTransactionExtractor,
+    },
+    utils::{
+        chain_id::check_or_update_chain_id,
+        database::{run_migrations, ArcDbPool},
+        starting_version::get_min_last_success_version_parquet,
+    },
+};
+use anyhow::Context;
+use aptos_indexer_processor_sdk::{
+    aptos_indexer_transaction_stream::{TransactionStream, TransactionStreamConfig},
+    builder::ProcessorBuilder,
+    common_steps::{TransactionStreamStep, DEFAULT_UPDATE_PROCESSOR_STATUS_SECS},
+    traits::{processor_trait::ProcessorTrait, IntoRunnableStep},
+};
+use parquet::schema::types::Type;
+use crate::{
+    bq_analytics::HasParquetSchema,
+    db::models::user_transaction_models::user_transactions::ParquetUserTransaction,
+};
+use std::{collections::HashMap, sync::Arc};
+use tracing::{debug, info};
+pub struct ParquetUserTransactionProcessor {
+    pub config: IndexerProcessorConfig,
+    pub db_pool: ArcDbPool,
+}
+
+impl ParquetUserTransactionProcessor {
+    pub async fn new(config: IndexerProcessorConfig) -> anyhow::Result<Self> {
+        let db_pool = initialize_database_pool(&config.db_config).await?;
+        Ok(Self { config, db_pool })
+    }
+}
+
+#[async_trait::async_trait]
+impl ProcessorTrait for ParquetUserTransactionProcessor {
+    fn name(&self) -> &'static str {
+        self.config.processor_config.name()
+    }
+
+    async fn run_processor(&self) -> anyhow::Result<()> {
+        // Run Migrations
+        let parquet_db_config = match self.config.db_config {
+            DbConfig::ParquetConfig(ref parquet_config) => {
+                run_migrations(
+                    parquet_config.connection_string.clone(),
+                    self.db_pool.clone(),
+                )
+                .await;
+                parquet_config
+            },
+            _ => {
+                return Err(anyhow::anyhow!(
+                    "Invalid db config for ParquetUserTransactionsProcessor {:?}",
+                    self.config.db_config
+                ));
+            },
+        };
+
+        // Check and update the ledger chain id to ensure we're indexing the correct chain
+        let grpc_chain_id = TransactionStream::new(self.config.transaction_stream_config.clone())
+            .await?
+            .get_chain_id()
+            .await?;
+        check_or_update_chain_id(grpc_chain_id as i64, self.db_pool.clone()).await?;
+
+        let parquet_processor_config = match self.config.processor_config.clone() {
+            ProcessorConfig::ParquetUserTransactionProcessor(parquet_processor_config) => {
+                parquet_processor_config
+            },
+            _ => {
+                return Err(anyhow::anyhow!(
+                    "Invalid processor configuration for ParquetUserTransactionProcessor {:?}",
+                    self.config.processor_config
+                ));
+            },
+        };
+
+        let processor_status_table_names = self
+            .config
+            .processor_config
+            .get_processor_status_table_names()
+            .context("Failed to get table names for the processor status table")?;
+
+        let starting_version = get_min_last_success_version_parquet(
+            &self.config,
+            self.db_pool.clone(),
+            processor_status_table_names,
+        )
+        .await?;
+        println!("Starting version: {:?}", starting_version);
+
+        // Define processor transaction stream config
+        let transaction_stream = TransactionStreamStep::new(TransactionStreamConfig {
+            starting_version: Some(starting_version),
+            ..self.config.transaction_stream_config.clone()
+        })
+        .await?;
+
+        let backfill_table = set_backfill_table_flag(parquet_processor_config.backfill_table);
+        let parquet_user_txn_extractor = ParquetUserTransactionExtractor {
+            opt_in_tables: backfill_table,
+        };
+
+        let gcs_client =
+            initialize_gcs_client(parquet_db_config.google_application_credentials.clone()).await;
+
+        let parquet_type_to_schemas: HashMap<ParquetTypeEnum, Arc<Type>> = [(
+            ParquetTypeEnum::UserTransactions,
+            ParquetUserTransaction::schema(),
+        )]
+        .into_iter()
+        .collect();
+
+        let default_size_buffer_step = initialize_parquet_buffer_step(
+            gcs_client.clone(),
+            parquet_type_to_schemas,
+            parquet_processor_config.upload_interval,
+            parquet_processor_config.max_buffer_size,
+            parquet_db_config.bucket_name.clone(),
+            parquet_db_config.bucket_root.clone(),
+            self.name().to_string(),
+        )
+        .await
+        .unwrap_or_else(|e| {
+            panic!("Failed to initialize parquet buffer step: {:?}", e);
+        });
+
+        let parquet_version_tracker_step = ParquetVersionTrackerStep::new(
+            get_processor_status_saver(self.db_pool.clone(), self.config.clone()),
+            DEFAULT_UPDATE_PROCESSOR_STATUS_SECS,
+        );
+
+        let channel_size = parquet_processor_config.channel_size;
+
+        // Connect processor steps together
+        let (_, buffer_receiver) = ProcessorBuilder::new_with_inputless_first_step(
+            transaction_stream.into_runnable_step(),
+        )
+        .connect_to(
+            parquet_user_txn_extractor.into_runnable_step(),
+            channel_size,
+        )
+        .connect_to(default_size_buffer_step.into_runnable_step(), channel_size)
+        .connect_to(
+            parquet_version_tracker_step.into_runnable_step(),
+            channel_size,
+        )
+        .end_and_return_output_receiver(channel_size);
+
+        loop {
+            match buffer_receiver.recv().await {
+                Ok(txn_context) => {
+                    debug!(
+                        "Finished processing versions [{:?}, {:?}]",
+                        txn_context.metadata.start_version, txn_context.metadata.end_version,
+                    );
+                },
+                Err(e) => {
+                    info!("No more transactions in channel: {:?}", e);
+                    break Ok(());
+                },
+            }
+        }
+    }
+}

--- a/processor/src/steps/parquet_processor_steps/mod.rs
+++ b/processor/src/steps/parquet_processor_steps/mod.rs
@@ -1,1 +1,2 @@
 pub mod parquet_default_processor;
+pub mod parquet_user_transaction_processor;

--- a/processor/src/steps/parquet_processor_steps/parquet_user_transaction_processor/mod.rs
+++ b/processor/src/steps/parquet_processor_steps/parquet_user_transaction_processor/mod.rs
@@ -1,0 +1,1 @@
+pub mod parquet_user_transaction_extractor;

--- a/processor/src/steps/parquet_processor_steps/parquet_user_transaction_processor/parquet_user_transaction_extractor.rs
+++ b/processor/src/steps/parquet_processor_steps/parquet_user_transaction_processor/parquet_user_transaction_extractor.rs
@@ -1,0 +1,75 @@
+use crate::{
+    db::models::user_transaction_models::user_transactions::ParquetUserTransaction,
+    parquet_processors::{ParquetTypeEnum, ParquetTypeStructs},
+    parsing::user_transaction_processor_helpers::user_transaction_parse,
+    utils::{
+        parquet_extractor_helper::add_to_map_if_opted_in_for_backfill, table_flags::TableFlags,
+    },
+};
+use aptos_indexer_processor_sdk::{
+    aptos_protos::transaction::v1::Transaction,
+    traits::{async_step::AsyncRunType, AsyncStep, NamedStep, Processable},
+    types::transaction_context::TransactionContext,
+    utils::errors::ProcessorError,
+};
+use async_trait::async_trait;
+use std::collections::HashMap;
+use tracing::debug;
+
+/// Extracts parquet data from transactions, allowing optional selection of specific tables.
+pub struct ParquetUserTransactionExtractor
+where
+    Self: Processable + Send + Sized + 'static,
+{
+    pub opt_in_tables: TableFlags,
+}
+
+type ParquetTypeMap = HashMap<ParquetTypeEnum, ParquetTypeStructs>;
+
+#[async_trait]
+impl Processable for ParquetUserTransactionExtractor {
+    type Input = Vec<Transaction>;
+    type Output = ParquetTypeMap;
+    type RunType = AsyncRunType;
+
+    async fn process(
+        &mut self,
+        transactions: TransactionContext<Self::Input>,
+    ) -> anyhow::Result<Option<TransactionContext<ParquetTypeMap>>, ProcessorError> {
+        let (user_txns, _) = user_transaction_parse(transactions.data.clone());
+
+        let parquet_user_txns: Vec<ParquetUserTransaction> = user_txns
+            .into_iter()
+            .map(ParquetUserTransaction::from)
+            .collect();
+
+        // Print the size of each extracted data type
+        debug!("Processed data sizes:");
+        debug!(" - UserTransactions: {}", parquet_user_txns.len());
+
+        let mut map: HashMap<ParquetTypeEnum, ParquetTypeStructs> = HashMap::new();
+
+        // Array of tuples for each data type and its corresponding enum variant and flag
+        let data_types = [(
+            TableFlags::USER_TRANSACTIONS,
+            ParquetTypeEnum::UserTransactions,
+            ParquetTypeStructs::UserTransaction(parquet_user_txns),
+        )];
+
+        // Populate the map based on opt-in tables
+        add_to_map_if_opted_in_for_backfill(self.opt_in_tables, &mut map, data_types.to_vec());
+
+        Ok(Some(TransactionContext {
+            data: map,
+            metadata: transactions.metadata,
+        }))
+    }
+}
+
+impl AsyncStep for ParquetUserTransactionExtractor {}
+
+impl NamedStep for ParquetUserTransactionExtractor {
+    fn name(&self) -> String {
+        "ParquetUserTransactionExtractor".to_string()
+    }
+}


### PR DESCRIPTION
### TL;DR
Migrated Parquet user transaction processor

### What changed?
- renamed from `UserTransactionsProcessor` to `UserTransactionProcessor`

### Test Plan
did a spot QC and compared with DE's teams BIgQuery Table. 


![Screenshot 2025-02-05 at 10.42.03 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XVbPtMdqqe4K1PNnLQvf/58fb93b8-917e-4abc-90ce-f053dc3d33b1.png)

![Screenshot 2025-02-05 at 10.41.57 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XVbPtMdqqe4K1PNnLQvf/7b16a82c-5366-4fd6-98ee-39283b8ed034.png)

![Screenshot 2025-02-05 at 10.38.55 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XVbPtMdqqe4K1PNnLQvf/4330385e-370b-496e-a83c-f36146a58bdf.png)

![Screenshot 2025-02-05 at 10.38.45 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XVbPtMdqqe4K1PNnLQvf/5617f111-b6d5-4422-9847-4c1dee732ed0.png)

![Screenshot 2025-02-05 at 10.38.39 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XVbPtMdqqe4K1PNnLQvf/f52db3d7-662e-4267-997a-53015877c0f6.png)

