### PR TITLE
Migrate objects processor

### DIFF
--- a/integration-tests/src/diff_test_helper/objects_processor.rs
+++ b/integration-tests/src/diff_test_helper/objects_processor.rs
@@ -1,10 +1,6 @@
 use crate::models::objects_models::{CurrentObject, Object};
 use anyhow::Result;
-use diesel::{
-    pg::PgConnection,
-    query_dsl::methods::{FilterDsl, ThenOrderDsl},
-    ExpressionMethods, RunQueryDsl,
-};
+use diesel::{pg::PgConnection, ExpressionMethods, QueryDsl, RunQueryDsl};
 use processor::schema::{current_objects::dsl as co_dsl, objects::dsl as o_dsl};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -12,13 +8,12 @@ use std::collections::HashMap;
 #[allow(dead_code)]
 pub fn load_data(
     conn: &mut PgConnection,
-    txn_versions: Vec<i64>,
+    _txn_versions: Vec<i64>, // TODO: remove this once testing framework is updated
 ) -> Result<HashMap<String, Value>> {
     let mut result_map: HashMap<String, Value> = HashMap::new();
 
     let objects_result = o_dsl::objects
-        .filter(o_dsl::transaction_version.eq_any(&txn_versions))
-        .then_order_by(o_dsl::transaction_version.asc())
+        .order_by(o_dsl::transaction_version.asc())
         .load::<Object>(conn)?;
     result_map.insert(
         "objects".to_string(),
@@ -26,8 +21,7 @@ pub fn load_data(
     );
 
     let current_objects_result = co_dsl::current_objects
-        .filter(co_dsl::last_transaction_version.eq_any(&txn_versions))
-        .then_order_by(co_dsl::last_transaction_version.asc())
+        .order_by(co_dsl::last_transaction_version.asc())
         .load::<CurrentObject>(conn)?;
     result_map.insert(
         "current_objects".to_string(),

--- a/integration-tests/src/sdk_tests/mod.rs
+++ b/integration-tests/src/sdk_tests/mod.rs
@@ -30,8 +30,8 @@ pub mod account_transaction_processor_tests;
 
 #[cfg(test)]
 pub mod default_processor_tests;
-// #[cfg(test)]
-// pub mod objects_processor_tests;
+#[cfg(test)]
+pub mod objects_processor_tests;
 #[cfg(test)]
 pub mod account_restoration_processor_tests;
 #[cfg(test)]

--- a/integration-tests/src/sdk_tests/objects_processor_tests.rs
+++ b/integration-tests/src/sdk_tests/objects_processor_tests.rs
@@ -1,6 +1,6 @@
 use ahash::AHashMap;
 use aptos_indexer_testing_framework::sdk_test_context::SdkTestContext;
-use sdk_processor::{
+use processor::{
     config::{
         db_config::{DbConfig, PostgresConfig},
         indexer_processor_config::IndexerProcessorConfig,
@@ -64,7 +64,7 @@ mod sdk_objects_processor_tests {
         IMPORTED_MAINNET_TXNS_578366445_TOKEN_V2_BURN_EVENT_V2,
     };
     use aptos_indexer_testing_framework::{cli_parser::get_test_config, database::TestDatabase};
-    use sdk_processor::processors::objects_processor::ObjectsProcessor;
+    use processor::processors::objects_processor::ObjectsProcessor;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_objects_write_and_delete_resource() {
@@ -74,7 +74,7 @@ mod sdk_objects_processor_tests {
             IMPORTED_MAINNET_TXNS_578318306_OBJECTS_WRITE_RESOURCE,
             IMPORTED_MAINNET_TXNS_578366445_TOKEN_V2_BURN_EVENT_V2,
         ];
-        process_multiple_transactions(
+        process_object_txns(
             txns,
             Some("test_objects_write_and_delete_resource".to_string()),
         )
@@ -85,18 +85,17 @@ mod sdk_objects_processor_tests {
     async fn test_delete_object_without_write() {
         // Testing that a delete resource with no matching write resource will not write that row to DB.
         let txns = &[IMPORTED_MAINNET_TXNS_578366445_TOKEN_V2_BURN_EVENT_V2];
-        process_multiple_transactions(txns, Some("test_delete_object_without_write".to_string()))
-            .await;
+        process_object_txns(txns, Some("test_delete_object_without_write".to_string())).await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_untransferable_object() {
         let txns = &[IMPORTED_MAINNET_TXNS_1806220919_OBJECT_UNTRANSFERABLE];
-        process_multiple_transactions(txns, Some("test_untransferable".to_string())).await;
+        process_object_txns(txns, Some("test_untransferable".to_string())).await;
     }
 
     // Helper function to abstract out the transaction processing
-    async fn process_multiple_transactions(txns: &[&[u8]], test_case_name: Option<String>) {
+    async fn process_object_txns(txns: &[&[u8]], test_case_name: Option<String>) {
         let (diff_flag, custom_output_path) = get_test_config();
         let output_path = custom_output_path.unwrap_or_else(|| DEFAULT_OUTPUT_FOLDER.to_string());
 

--- a/processor/src/config/indexer_processor_config.rs
+++ b/processor/src/config/indexer_processor_config.rs
@@ -17,8 +17,9 @@ use crate::{
         account_restoration_processor::AccountRestorationProcessor,
         account_transactions_processor::AccountTransactionsProcessor, ans_processor::AnsProcessor,
         default_processor::DefaultProcessor, events_processor::EventsProcessor,
-        monitoring_processor::MonitoringProcessor, stake_processor::StakeProcessor,
-        token_v2_processor::TokenV2Processor, user_transaction_processor::UserTransactionProcessor,
+        monitoring_processor::MonitoringProcessor, objects_processor::ObjectsProcessor,
+        stake_processor::StakeProcessor, token_v2_processor::TokenV2Processor,
+        user_transaction_processor::UserTransactionProcessor,
     },
 };
 use anyhow::Result;
@@ -85,10 +86,10 @@ impl RunnableConfig for IndexerProcessorConfig {
                 let token_v2_processor = TokenV2Processor::new(self.clone()).await?;
                 token_v2_processor.run_processor().await
             },
-            // ProcessorConfig::ObjectsProcessor(_) => {
-            //     let objects_processor = ObjectsProcessor::new(self.clone()).await?;
-            //     objects_processor.run_processor().await
-            // },
+            ProcessorConfig::ObjectsProcessor(_) => {
+                let objects_processor = ObjectsProcessor::new(self.clone()).await?;
+                objects_processor.run_processor().await
+            },
             ProcessorConfig::ParquetDefaultProcessor(_) => {
                 let parquet_default_processor = ParquetDefaultProcessor::new(self.clone()).await?;
                 parquet_default_processor.run_processor().await

--- a/processor/src/config/processor_config.rs
+++ b/processor/src/config/processor_config.rs
@@ -44,10 +44,11 @@ use crate::{
 };
 use crate::{
     //     parquet_processors::parquet_ans_processor::ParquetAnsProcessorConfig,
-    //     processors::{
-    //         ans_processor::AnsProcessorConfig, objects_processor::ObjectsProcessorConfig,
-    //         stake_processor::StakeProcessorConfig, token_v2_processor::TokenV2ProcessorConfig,
-    //     },
+    processors::{
+        objects_processor::ObjectsProcessorConfig,
+        // ans_processor::AnsProcessorConfig,
+        // stake_processor::StakeProcessorConfig, token_v2_processor::TokenV2ProcessorConfig,
+    },
     utils::parquet_processor_table_mapping::{format_table_name, VALID_TABLE_NAMES},
 };
 use ahash::AHashMap;
@@ -97,7 +98,7 @@ pub enum ProcessorConfig {
     UserTransactionProcessor(DefaultProcessorConfig),
     StakeProcessor(StakeProcessorConfig),
     TokenV2Processor(TokenV2ProcessorConfig),
-    // ObjectsProcessor(ObjectsProcessorConfig), // TODO: Add this back when we migrate the processor
+    ObjectsProcessor(ObjectsProcessorConfig),
     MonitoringProcessor(DefaultProcessorConfig),
     // ParquetProcessor
     ParquetDefaultProcessor(ParquetDefaultProcessorConfig),

--- a/processor/src/db/models/object_models/v2_objects.rs
+++ b/processor/src/db/models/object_models/v2_objects.rs
@@ -41,11 +41,6 @@ pub struct Object {
     pub untransferrable: bool,
     pub block_timestamp: chrono::NaiveDateTime,
 }
-
-pub trait ObjectConvertible {
-    fn from_raw(base_item: Object) -> Self;
-}
-
 #[derive(Clone, Debug, Deserialize, FieldCount, Serialize)]
 pub struct CurrentObject {
     pub object_address: String,
@@ -57,10 +52,6 @@ pub struct CurrentObject {
     pub is_deleted: bool,
     pub untransferrable: bool,
     pub block_timestamp: chrono::NaiveDateTime,
-}
-
-pub trait CurrentObjectConvertible {
-    fn from_raw(base_item: CurrentObject) -> Self;
 }
 
 #[derive(Debug, Deserialize, Identifiable, Queryable, Serialize)]
@@ -330,8 +321,8 @@ impl HasVersion for ParquetObject {
     }
 }
 
-impl ObjectConvertible for ParquetObject {
-    fn from_raw(base_item: Object) -> Self {
+impl From<Object> for ParquetObject {
+    fn from(base_item: Object) -> Self {
         Self {
             txn_version: base_item.transaction_version,
             write_set_change_index: base_item.write_set_change_index,
@@ -373,8 +364,8 @@ impl HasVersion for ParquetCurrentObject {
     }
 }
 
-impl CurrentObjectConvertible for ParquetCurrentObject {
-    fn from_raw(base_item: CurrentObject) -> Self {
+impl From<CurrentObject> for ParquetCurrentObject {
+    fn from(base_item: CurrentObject) -> Self {
         Self {
             object_address: base_item.object_address,
             owner_address: base_item.owner_address,
@@ -405,8 +396,8 @@ pub struct PostgresObject {
     pub untransferrable: bool,
 }
 
-impl ObjectConvertible for PostgresObject {
-    fn from_raw(base_item: Object) -> Self {
+impl From<Object> for PostgresObject {
+    fn from(base_item: Object) -> Self {
         Self {
             transaction_version: base_item.transaction_version,
             write_set_change_index: base_item.write_set_change_index,
@@ -435,17 +426,17 @@ pub struct PostgresCurrentObject {
     pub untransferrable: bool,
 }
 
-impl CurrentObjectConvertible for PostgresCurrentObject {
-    fn from_raw(base_item: CurrentObject) -> Self {
+impl From<CurrentObject> for PostgresCurrentObject {
+    fn from(raw: CurrentObject) -> Self {
         Self {
-            object_address: base_item.object_address,
-            owner_address: base_item.owner_address,
-            state_key_hash: base_item.state_key_hash,
-            allow_ungated_transfer: base_item.allow_ungated_transfer,
-            last_guid_creation_num: base_item.last_guid_creation_num,
-            last_transaction_version: base_item.last_transaction_version,
-            is_deleted: base_item.is_deleted,
-            untransferrable: base_item.untransferrable,
+            object_address: raw.object_address,
+            owner_address: raw.owner_address,
+            state_key_hash: raw.state_key_hash,
+            allow_ungated_transfer: raw.allow_ungated_transfer,
+            last_guid_creation_num: raw.last_guid_creation_num,
+            last_transaction_version: raw.last_transaction_version,
+            is_deleted: raw.is_deleted,
+            untransferrable: raw.untransferrable,
         }
     }
 }

--- a/processor/src/db/queries/mod.rs
+++ b/processor/src/db/queries/mod.rs
@@ -3,6 +3,7 @@ pub mod account_transaction_processor_queries;
 pub mod ans_processor_queries;
 pub mod default_processor_queries;
 pub mod events_processor_queries;
+pub mod objects_processor_queries;
 pub mod stake_processor_queries;
 pub mod token_v2_processor_queries;
 pub mod user_transaction_queries;

--- a/processor/src/db/queries/objects_processor_queries.rs
+++ b/processor/src/db/queries/objects_processor_queries.rs
@@ -1,0 +1,54 @@
+use crate::{
+    db::models::object_models::v2_objects::{PostgresCurrentObject, PostgresObject},
+    schema,
+};
+use diesel::{
+    pg::{upsert::excluded, Pg},
+    query_builder::QueryFragment,
+    ExpressionMethods,
+};
+
+pub fn insert_objects_query(
+    items_to_insert: Vec<PostgresObject>,
+) -> (
+    impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
+    Option<&'static str>,
+) {
+    use schema::objects::dsl::*;
+    (
+        diesel::insert_into(schema::objects::table)
+            .values(items_to_insert)
+            .on_conflict((transaction_version, write_set_change_index))
+            .do_update()
+            .set((inserted_at.eq(excluded(inserted_at)),)),
+        None,
+    )
+}
+
+pub fn insert_current_objects_query(
+    items_to_insert: Vec<PostgresCurrentObject>,
+) -> (
+    impl QueryFragment<Pg> + diesel::query_builder::QueryId + Send,
+    Option<&'static str>,
+) {
+    use schema::current_objects::dsl::*;
+    (
+        diesel::insert_into(schema::current_objects::table)
+            .values(items_to_insert)
+            .on_conflict(object_address)
+            .do_update()
+            .set((
+                owner_address.eq(excluded(owner_address)),
+                state_key_hash.eq(excluded(state_key_hash)),
+                allow_ungated_transfer.eq(excluded(allow_ungated_transfer)),
+                last_guid_creation_num.eq(excluded(last_guid_creation_num)),
+                last_transaction_version.eq(excluded(last_transaction_version)),
+                is_deleted.eq(excluded(is_deleted)),
+                inserted_at.eq(excluded(inserted_at)),
+                untransferrable.eq(excluded(untransferrable)),
+            )),
+        Some(
+            " WHERE current_objects.last_transaction_version <= excluded.last_transaction_version ",
+        ),
+    )
+}

--- a/processor/src/parsing/mod.rs
+++ b/processor/src/parsing/mod.rs
@@ -3,6 +3,7 @@ pub mod account_transaction_processor_helpers;
 pub mod ans_processor_helpers;
 pub mod default_processor_helpers;
 pub mod events_processor_helpers;
+pub mod objects_processor_helpers;
 pub mod stake_processor_helpers;
 pub mod token_v2_processor_helpers;
 pub mod transaction_metadata_processor_helpers;

--- a/processor/src/parsing/objects_processor_helpers.rs
+++ b/processor/src/parsing/objects_processor_helpers.rs
@@ -1,0 +1,142 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    db::{
+        models::object_models::{
+            v2_object_utils::{
+                ObjectAggregatedData, ObjectAggregatedDataMapping, ObjectWithMetadata,
+                Untransferable,
+            },
+            v2_objects::{CurrentObject, Object},
+        },
+        resources::FromWriteResource,
+    },
+    utils::{
+        database::DbContext,
+        util::{parse_timestamp, standardize_address},
+    },
+};
+use ahash::AHashMap;
+use aptos_protos::transaction::v1::{write_set_change::Change, Transaction};
+
+pub async fn process_objects(
+    transactions: Vec<Transaction>,
+    db_context: &mut Option<DbContext<'_>>,
+) -> (Vec<Object>, Vec<CurrentObject>) {
+    // Moving object handling here because we need a single object
+    // map through transactions for lookups
+    let mut all_objects = vec![];
+    let mut all_current_objects = AHashMap::new();
+    let mut object_metadata_helper: ObjectAggregatedDataMapping = AHashMap::new();
+
+    for txn in &transactions {
+        let txn_version = txn.version as i64;
+        let changes = &txn
+            .info
+            .as_ref()
+            .unwrap_or_else(|| {
+                panic!(
+                    "Transaction info doesn't exist! Transaction {}",
+                    txn_version
+                )
+            })
+            .changes;
+
+        let txn_timestamp = parse_timestamp(txn.timestamp.as_ref().unwrap(), txn_version);
+
+        // First pass to get all the object cores
+        for wsc in changes.iter() {
+            if let Change::WriteResource(wr) = wsc.change.as_ref().unwrap() {
+                let address: String = standardize_address(&wr.address.to_string());
+                if let Some(object_with_metadata) =
+                    ObjectWithMetadata::from_write_resource(wr).unwrap()
+                {
+                    // Object core is the first struct that we need to get
+                    object_metadata_helper.insert(address.clone(), ObjectAggregatedData {
+                        object: object_with_metadata,
+                        token: None,
+                        fungible_asset_store: None,
+                        // The following structs are unused in this processor
+                        fungible_asset_metadata: None,
+                        aptos_collection: None,
+                        fixed_supply: None,
+                        unlimited_supply: None,
+                        concurrent_supply: None,
+                        property_map: None,
+                        transfer_events: vec![],
+                        untransferable: None,
+                        fungible_asset_supply: None,
+                        concurrent_fungible_asset_supply: None,
+                        concurrent_fungible_asset_balance: None,
+                        token_identifier: None,
+                    });
+                }
+            }
+        }
+
+        // Second pass to get object metadata
+        for wsc in changes.iter() {
+            if let Change::WriteResource(write_resource) = wsc.change.as_ref().unwrap() {
+                let address = standardize_address(&write_resource.address.to_string());
+                if let Some(aggregated_data) = object_metadata_helper.get_mut(&address) {
+                    if let Some(untransferable) =
+                        Untransferable::from_write_resource(write_resource).unwrap()
+                    {
+                        aggregated_data.untransferable = Some(untransferable);
+                    }
+                }
+            }
+        }
+
+        // Second pass to construct the object data
+        for (index, wsc) in changes.iter().enumerate() {
+            let index: i64 = index as i64;
+            match wsc.change.as_ref().unwrap() {
+                Change::WriteResource(inner) => {
+                    if let Some((object, current_object)) = &Object::from_write_resource(
+                        inner,
+                        txn_version,
+                        index,
+                        &object_metadata_helper,
+                        txn_timestamp,
+                    )
+                    .unwrap()
+                    {
+                        all_objects.push(object.clone());
+                        all_current_objects
+                            .insert(object.object_address.clone(), current_object.clone());
+                    }
+                },
+                Change::DeleteResource(inner) => {
+                    // Passing all_current_objects into the function so that we can get the owner of the deleted
+                    // resource if it was handled in the same batch
+                    if let Some((object, current_object)) = Object::from_delete_resource(
+                        inner,
+                        txn_version,
+                        index,
+                        &all_current_objects,
+                        db_context,
+                        txn_timestamp,
+                    )
+                    .await
+                    .unwrap()
+                    {
+                        all_objects.push(object.clone());
+                        all_current_objects
+                            .insert(object.object_address.clone(), current_object.clone());
+                    }
+                },
+                _ => {},
+            };
+        }
+    }
+
+    // Sort by PK
+    let mut all_current_objects = all_current_objects
+        .into_values()
+        .collect::<Vec<CurrentObject>>();
+    all_current_objects.sort_by(|a, b| a.object_address.cmp(&b.object_address));
+
+    (all_objects, all_current_objects)
+}

--- a/processor/src/processors/mod.rs
+++ b/processor/src/processors/mod.rs
@@ -4,6 +4,7 @@ pub mod ans_processor;
 pub mod default_processor;
 pub mod events_processor;
 pub mod monitoring_processor;
+pub mod objects_processor;
 pub mod stake_processor;
 pub mod token_v2_processor;
 pub mod user_transaction_processor;

--- a/processor/src/processors/objects_processor.rs
+++ b/processor/src/processors/objects_processor.rs
@@ -1,0 +1,162 @@
+use crate::{
+    config::{
+        db_config::DbConfig,
+        indexer_processor_config::{
+            IndexerProcessorConfig, QUERY_DEFAULT_RETRIES, QUERY_DEFAULT_RETRY_DELAY_MS,
+        },
+        processor_config::{DefaultProcessorConfig, ProcessorConfig},
+    },
+    steps::{
+        common::get_processor_status_saver,
+        postgres_processor_steps::objects_processor::{
+            objects_extractor::ObjectsExtractor, objects_storer::ObjectsStorer,
+        },
+    },
+    utils::{
+        chain_id::check_or_update_chain_id,
+        database::{new_db_pool, run_migrations, ArcDbPool},
+        starting_version::get_starting_version,
+    },
+};
+use anyhow::Result;
+use aptos_indexer_processor_sdk::{
+    aptos_indexer_transaction_stream::{TransactionStream, TransactionStreamConfig},
+    builder::ProcessorBuilder,
+    common_steps::{
+        TransactionStreamStep, VersionTrackerStep, DEFAULT_UPDATE_PROCESSOR_STATUS_SECS,
+    },
+    traits::{processor_trait::ProcessorTrait, IntoRunnableStep},
+};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, info};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ObjectsProcessorConfig {
+    #[serde(flatten)]
+    pub default_config: DefaultProcessorConfig,
+    #[serde(default = "ObjectsProcessorConfig::default_query_retries")]
+    pub query_retries: u32,
+    #[serde(default = "ObjectsProcessorConfig::default_query_retry_delay_ms")]
+    pub query_retry_delay_ms: u64,
+}
+
+impl ObjectsProcessorConfig {
+    pub const fn default_query_retries() -> u32 {
+        QUERY_DEFAULT_RETRIES
+    }
+
+    pub const fn default_query_retry_delay_ms() -> u64 {
+        QUERY_DEFAULT_RETRY_DELAY_MS
+    }
+}
+pub struct ObjectsProcessor {
+    pub config: IndexerProcessorConfig,
+    pub db_pool: ArcDbPool,
+}
+
+impl ObjectsProcessor {
+    pub async fn new(config: IndexerProcessorConfig) -> Result<Self> {
+        match config.db_config {
+            DbConfig::PostgresConfig(ref postgres_config) => {
+                let conn_pool = new_db_pool(
+                    &postgres_config.connection_string,
+                    Some(postgres_config.db_pool_size),
+                )
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "Failed to create connection pool for PostgresConfig: {:?}",
+                        e
+                    )
+                })?;
+
+                Ok(Self {
+                    config,
+                    db_pool: conn_pool,
+                })
+            },
+            _ => Err(anyhow::anyhow!(
+                "Invalid db config for ObjectsProcessor {:?}",
+                config.db_config
+            )),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ProcessorTrait for ObjectsProcessor {
+    fn name(&self) -> &'static str {
+        self.config.processor_config.name()
+    }
+
+    async fn run_processor(&self) -> Result<()> {
+        //  Run migrations
+        if let DbConfig::PostgresConfig(ref postgres_config) = self.config.db_config {
+            run_migrations(
+                postgres_config.connection_string.clone(),
+                self.db_pool.clone(),
+            )
+            .await;
+        }
+
+        // Merge the starting version from config and the latest processed version from the DB
+        let starting_version = get_starting_version(&self.config, self.db_pool.clone()).await?;
+
+        // Check and update the ledger chain id to ensure we're indexing the correct chain
+        let grpc_chain_id = TransactionStream::new(self.config.transaction_stream_config.clone())
+            .await?
+            .get_chain_id()
+            .await?;
+        check_or_update_chain_id(grpc_chain_id as i64, self.db_pool.clone()).await?;
+
+        let processor_config = match &self.config.processor_config {
+            ProcessorConfig::ObjectsProcessor(processor_config) => processor_config,
+            _ => return Err(anyhow::anyhow!("Processor config is wrong type")),
+        };
+        let channel_size = processor_config.default_config.channel_size;
+        let per_table_chunk_sizes = &processor_config.default_config.per_table_chunk_sizes;
+
+        // Define processor steps
+        let transaction_stream = TransactionStreamStep::new(TransactionStreamConfig {
+            starting_version: Some(starting_version),
+            ..self.config.transaction_stream_config.clone()
+        })
+        .await?;
+        let objects_extractor = ObjectsExtractor::new(
+            processor_config.query_retries,
+            processor_config.query_retry_delay_ms,
+            self.db_pool.clone(),
+        );
+        let objects_storer =
+            ObjectsStorer::new(self.db_pool.clone(), per_table_chunk_sizes.clone());
+
+        let version_tracker = VersionTrackerStep::new(
+            get_processor_status_saver(self.db_pool.clone(), self.config.clone()),
+            DEFAULT_UPDATE_PROCESSOR_STATUS_SECS,
+        );
+        // Connect processor steps together
+        let (_, buffer_receiver) = ProcessorBuilder::new_with_inputless_first_step(
+            transaction_stream.into_runnable_step(),
+        )
+        .connect_to(objects_extractor.into_runnable_step(), channel_size)
+        .connect_to(objects_storer.into_runnable_step(), channel_size)
+        .connect_to(version_tracker.into_runnable_step(), channel_size)
+        .end_and_return_output_receiver(channel_size);
+
+        loop {
+            match buffer_receiver.recv().await {
+                Ok(txn_context) => {
+                    debug!(
+                        "Finished processing versions [{:?}, {:?}]",
+                        txn_context.metadata.start_version, txn_context.metadata.end_version,
+                    );
+                },
+                Err(e) => {
+                    info!("No more transactions in channel: {:?}", e);
+                    break Ok(());
+                },
+            }
+        }
+    }
+}

--- a/processor/src/steps/postgres_processor_steps/mod.rs
+++ b/processor/src/steps/postgres_processor_steps/mod.rs
@@ -4,6 +4,7 @@ pub mod account_transactions_processor;
 pub mod ans_processor;
 pub mod default_processor;
 pub mod events_processor;
+pub mod objects_processor;
 pub mod stake_processor;
 pub mod token_v2_processor;
 pub mod user_transaction_processor;

--- a/processor/src/steps/postgres_processor_steps/objects_processor/mod.rs
+++ b/processor/src/steps/postgres_processor_steps/objects_processor/mod.rs
@@ -1,0 +1,2 @@
+pub mod objects_extractor;
+pub mod objects_storer;

--- a/processor/src/steps/postgres_processor_steps/objects_processor/objects_extractor.rs
+++ b/processor/src/steps/postgres_processor_steps/objects_processor/objects_extractor.rs
@@ -1,0 +1,87 @@
+use crate::{
+    db::models::object_models::v2_objects::{PostgresCurrentObject, PostgresObject},
+    parsing::objects_processor_helpers::process_objects,
+    utils::database::{ArcDbPool, DbContext},
+};
+use aptos_indexer_processor_sdk::{
+    aptos_protos::transaction::v1::Transaction,
+    traits::{async_step::AsyncRunType, AsyncStep, NamedStep, Processable},
+    types::transaction_context::TransactionContext,
+    utils::errors::ProcessorError,
+};
+use async_trait::async_trait;
+
+/// Extracts fungible asset events, metadata, balances, and v1 supply from transactions
+pub struct ObjectsExtractor
+where
+    Self: Sized + Send + 'static,
+{
+    query_retries: u32,
+    query_retry_delay_ms: u64,
+    conn_pool: ArcDbPool,
+}
+
+impl ObjectsExtractor {
+    pub fn new(query_retries: u32, query_retry_delay_ms: u64, conn_pool: ArcDbPool) -> Self {
+        Self {
+            query_retries,
+            query_retry_delay_ms,
+            conn_pool,
+        }
+    }
+}
+
+#[async_trait]
+impl Processable for ObjectsExtractor {
+    type Input = Vec<Transaction>;
+    type Output = (Vec<PostgresObject>, Vec<PostgresCurrentObject>);
+    type RunType = AsyncRunType;
+
+    async fn process(
+        &mut self,
+        transactions: TransactionContext<Vec<Transaction>>,
+    ) -> Result<
+        Option<TransactionContext<(Vec<PostgresObject>, Vec<PostgresCurrentObject>)>>,
+        ProcessorError,
+    > {
+        let conn = self
+            .conn_pool
+            .get()
+            .await
+            .map_err(|e| ProcessorError::DBStoreError {
+                message: format!("Failed to get connection from pool: {:?}", e),
+                query: None,
+            })?;
+        let query_retries = self.query_retries;
+        let query_retry_delay_ms = self.query_retry_delay_ms;
+        let db_connection = DbContext {
+            conn,
+            query_retries,
+            query_retry_delay_ms,
+        };
+
+        let (raw_objects, raw_all_current_objects) =
+            process_objects(transactions.data, &mut Some(db_connection)).await;
+
+        let postgres_objects: Vec<PostgresObject> =
+            raw_objects.into_iter().map(PostgresObject::from).collect();
+
+        let postgres_all_current_objects: Vec<PostgresCurrentObject> = raw_all_current_objects
+            .into_iter()
+            .map(PostgresCurrentObject::from)
+            .collect();
+
+        Ok(Some(TransactionContext {
+            data: (postgres_objects, postgres_all_current_objects),
+            metadata: transactions.metadata,
+        }))
+    }
+}
+
+impl AsyncStep for ObjectsExtractor {}
+
+impl NamedStep for ObjectsExtractor {
+    fn name(&self) -> String {
+        "ObjectsExtractor".to_string()
+    }
+}

--- a/processor/src/steps/postgres_processor_steps/objects_processor/objects_storer.rs
+++ b/processor/src/steps/postgres_processor_steps/objects_processor/objects_storer.rs
@@ -1,0 +1,92 @@
+use crate::{
+    db::{
+        models::object_models::v2_objects::{PostgresCurrentObject, PostgresObject},
+        queries::objects_processor_queries::{insert_current_objects_query, insert_objects_query},
+    },
+    utils::database::{execute_in_chunks, get_config_table_chunk_size, ArcDbPool},
+};
+use ahash::AHashMap;
+use anyhow::Result;
+use aptos_indexer_processor_sdk::{
+    traits::{async_step::AsyncRunType, AsyncStep, NamedStep, Processable},
+    types::transaction_context::TransactionContext,
+    utils::errors::ProcessorError,
+};
+use async_trait::async_trait;
+
+pub struct ObjectsStorer
+where
+    Self: Sized + Send + 'static,
+{
+    conn_pool: ArcDbPool,
+    per_table_chunk_sizes: AHashMap<String, usize>,
+}
+
+impl ObjectsStorer {
+    pub fn new(conn_pool: ArcDbPool, per_table_chunk_sizes: AHashMap<String, usize>) -> Self {
+        Self {
+            conn_pool,
+            per_table_chunk_sizes,
+        }
+    }
+}
+
+#[async_trait]
+impl Processable for ObjectsStorer {
+    type Input = (Vec<PostgresObject>, Vec<PostgresCurrentObject>);
+    type Output = ();
+    type RunType = AsyncRunType;
+
+    async fn process(
+        &mut self,
+        input: TransactionContext<(Vec<PostgresObject>, Vec<PostgresCurrentObject>)>,
+    ) -> Result<Option<TransactionContext<Self::Output>>, ProcessorError> {
+        let (objects, current_objects) = input.data;
+
+        let io = execute_in_chunks(
+            self.conn_pool.clone(),
+            insert_objects_query,
+            &objects,
+            get_config_table_chunk_size::<PostgresObject>("objects", &self.per_table_chunk_sizes),
+        );
+
+        let co = execute_in_chunks(
+            self.conn_pool.clone(),
+            insert_current_objects_query,
+            &current_objects,
+            get_config_table_chunk_size::<PostgresCurrentObject>(
+                "current_objects",
+                &self.per_table_chunk_sizes,
+            ),
+        );
+
+        let (io_res, co_res) = tokio::join!(io, co);
+        for res in [io_res, co_res] {
+            match res {
+                Ok(_) => {},
+                Err(e) => {
+                    return Err(ProcessorError::DBStoreError {
+                        message: format!(
+                            "Failed to store versions {} to {}: {:?}",
+                            input.metadata.start_version, input.metadata.end_version, e,
+                        ),
+                        query: None,
+                    })
+                },
+            }
+        }
+
+        Ok(Some(TransactionContext {
+            data: (),
+            metadata: input.metadata,
+        }))
+    }
+}
+
+impl AsyncStep for ObjectsStorer {}
+
+impl NamedStep for ObjectsStorer {
+    fn name(&self) -> String {
+        "ObjectsStorer".to_string()
+    }
+}


### PR DESCRIPTION
### TL;DR
Migrated Objects Processor

### What changed?
- Added database queries for objects and current objects tables
- Updated object model implementations to use From trait instead of custom traits
- Added helper functions for processing object data
- Re-enabled objects processor tests
- Removed transaction version filtering from integration tests

### How to test?

![Screenshot 2025-02-05 at 4.01.26 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XVbPtMdqqe4K1PNnLQvf/f8f9c274-cfc2-470a-b3b4-68b56e0aa5d3.png)

![Screenshot 2025-02-05 at 4.04.22 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XVbPtMdqqe4K1PNnLQvf/bbaa9e5c-902e-4b10-bc1d-9a0e9f24d005.png)

