### PR TITLE
update build script to push image to correct path

### DIFF
--- a/scripts/build_and_push_images.sh
+++ b/scripts/build_and_push_images.sh
@@ -10,7 +10,7 @@
 
 set -ex
 
-TARGET_REGISTRY="us-docker.pkg.dev/aptos-registry/docker/aptos-indexer-processors-v2"
+TARGET_REGISTRY="us-docker.pkg.dev/aptos-registry/docker/indexer-client-examples/rust"
 # take GIT_SHA from environment variable if set, otherwise use git rev-parse HEAD
 GIT_SHA="${GIT_SHA:-$(git rev-parse HEAD)}"
 EXAMPLE_TO_BUILD_ARG="${1:-all}"


### PR DESCRIPTION
### Description
Update the build script to push docker image to the same path as the legacy so that internal opts k8s code can find the image and deploy this new repo processors to devnet