### PR TITLE
update fa metadata column length limit

### DIFF
--- a/processor/src/db/migrations/2025-02-21-192151_fa_metadata_symbol/down.sql
+++ b/processor/src/db/migrations/2025-02-21-192151_fa_metadata_symbol/down.sql
@@ -1,0 +1,19 @@
+-- This file should undo anything in `up.sql`
+DROP VIEW IF EXISTS legacy_migration_v1.coin_infos;
+ALTER TABLE public.fungible_asset_metadata ALTER COLUMN symbol TYPE VARCHAR(10);
+
+-- Recreate the view with the original column type
+CREATE OR REPLACE VIEW legacy_migration_v1.coin_infos AS
+SELECT encode(sha256(asset_type::bytea), 'hex') as coin_type_hash,
+    asset_type as coin_type,
+    last_transaction_version as transaction_version_created,
+    creator_address,
+    name,
+    symbol,  -- The symbol column is now back to VARCHAR(10)
+    decimals,
+    last_transaction_timestamp as transaction_created_timestamp,
+    inserted_at,
+    supply_aggregator_table_handle_v1 as supply_aggregator_table_handle,
+    supply_aggregator_table_key_v1 as supply_aggregator_table_key
+FROM public.fungible_asset_metadata
+WHERE token_standard = 'v1';

--- a/processor/src/db/migrations/2025-02-21-192151_fa_metadata_symbol/up.sql
+++ b/processor/src/db/migrations/2025-02-21-192151_fa_metadata_symbol/up.sql
@@ -1,0 +1,21 @@
+-- Your SQL goes here
+-- Drop the view that uses the symbol column
+DROP VIEW IF EXISTS legacy_migration_v1.coin_infos;
+
+ALTER TABLE public.fungible_asset_metadata ALTER COLUMN symbol TYPE VARCHAR(32);
+
+-- Recreate the view with the updated column type (and any other necessary changes)
+CREATE OR REPLACE VIEW legacy_migration_v1.coin_infos AS
+SELECT encode(sha256(asset_type::bytea), 'hex') as coin_type_hash,
+    asset_type as coin_type,
+    last_transaction_version as transaction_version_created,
+    creator_address,
+    name,
+    symbol,  -- The symbol column is now VARCHAR(32)
+    decimals,
+    last_transaction_timestamp as transaction_created_timestamp,
+    inserted_at,
+    supply_aggregator_table_handle_v1 as supply_aggregator_table_handle,
+    supply_aggregator_table_key_v1 as supply_aggregator_table_key
+FROM public.fungible_asset_metadata
+WHERE token_standard = 'v1';

--- a/processor/src/processors/fungible_asset/fungible_asset_models/v2_fungible_asset_utils.rs
+++ b/processor/src/processors/fungible_asset/fungible_asset_models/v2_fungible_asset_utils.rs
@@ -17,7 +17,7 @@ use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
 const FUNGIBLE_ASSET_LENGTH: usize = 32;
-const FUNGIBLE_ASSET_SYMBOL: usize = 10;
+const FUNGIBLE_ASSET_SYMBOL: usize = 32;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct FeeStatement {


### PR DESCRIPTION
### TL;DR
Increased the maximum length of fungible asset symbols from 10 to 32.

### What changed?
- Modified the `fungible_asset_metadata` table to increase the `symbol` column from VARCHAR(10) to VARCHAR(32)
- Updated the `FUNGIBLE_ASSET_SYMBOL` constant from 10 to 32 in the Rust code
- Updated the `legacy_migration_v1.coin_infos` view to accommodate the new column type

### How to test?

![Screenshot 2025-02-21 at 11.54.14 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XVbPtMdqqe4K1PNnLQvf/f0fd3f28-c6d6-4f47-84df-5057c0d6c6f4.png)

![Screenshot 2025-02-21 at 11.53.40 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XVbPtMdqqe4K1PNnLQvf/9f804a70-91c0-40c8-aa44-17a826f34215.png)

![Screenshot 2025-02-21 at 12.01.55 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XVbPtMdqqe4K1PNnLQvf/68b5477b-6af4-40c3-903e-d948a573f058.png)

