### PR TITLE
fix parquet user transaction processor

### DIFF
--- a/processor/src/parquet_processors/parquet_user_transaction/parquet_user_transaction_processor.rs
+++ b/processor/src/parquet_processors/parquet_user_transaction/parquet_user_transaction_processor.rs
@@ -13,7 +13,9 @@ use crate::{
     },
     processors::{
         processor_status_saver::get_processor_status_saver,
-        user_transaction::models::user_transactions::ParquetUserTransaction,
+        user_transaction::models::{
+            signatures::ParquetSignature, user_transactions::ParquetUserTransaction,
+        },
     },
     utils::{
         chain_id::check_or_update_chain_id,
@@ -116,10 +118,13 @@ impl ProcessorTrait for ParquetUserTransactionProcessor {
         let gcs_client =
             initialize_gcs_client(parquet_db_config.google_application_credentials.clone()).await;
 
-        let parquet_type_to_schemas: HashMap<ParquetTypeEnum, Arc<Type>> = [(
-            ParquetTypeEnum::UserTransactions,
-            ParquetUserTransaction::schema(),
-        )]
+        let parquet_type_to_schemas: HashMap<ParquetTypeEnum, Arc<Type>> = [
+            (
+                ParquetTypeEnum::UserTransactions,
+                ParquetUserTransaction::schema(),
+            ),
+            (ParquetTypeEnum::Signatures, ParquetSignature::schema()),
+        ]
         .into_iter()
         .collect();
 


### PR DESCRIPTION
### TL;DR
Added signature schema support to the parquet user transaction processor.

![Screenshot 2025-02-26 at 3.26.45 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XVbPtMdqqe4K1PNnLQvf/db519bd8-40f3-4946-b512-221047dabad9.png)

deployed parquet user transaction processor in devnet and it's crashlooping right now due to this. 

### What changed?
Added `ParquetSignature::schema()` to the `parquet_type_to_schemas` HashMap, enabling the processor to handle signature-related parquet data alongside user transactions.

### How to test?

![Screenshot 2025-02-26 at 3.26.39 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XVbPtMdqqe4K1PNnLQvf/60ae086b-5c1a-4599-9d0d-b1e2c07e1c5c.png)

![Screenshot 2025-02-26 at 3.26.28 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XVbPtMdqqe4K1PNnLQvf/0753c495-515f-4019-bd9a-9d621cd6ba76.png)

