### PR TITLE
fix signatures parquet primary key

### DIFF
--- a/integration-tests/src/models/account_transaction_models.rs
+++ b/integration-tests/src/models/account_transaction_models.rs
@@ -6,7 +6,10 @@
 #![allow(clippy::unused_unit)]
 
 use ahash::AHashSet;
-use aptos_indexer_processor_sdk::utils::convert::standardize_address;
+use aptos_indexer_processor_sdk::{
+    aptos_indexer_transaction_stream::utils::time::parse_timestamp,
+    utils::convert::standardize_address,
+};
 use aptos_protos::transaction::v1::{transaction::TxnData, write_set_change::Change, Transaction};
 use diesel::{Identifiable, Insertable, Queryable};
 use field_count::FieldCount;
@@ -66,6 +69,8 @@ impl AccountTransaction {
                     }),
                     txn_version,
                     transaction.block_height as i64,
+                    parse_timestamp(transaction.timestamp.as_ref().unwrap(), txn_version)
+                        .naive_utc(),
                 ),
             ),
             TxnData::Genesis(inner) => (&inner.events, vec![]),

--- a/processor/src/processors/account_transactions/account_transactions_model.rs
+++ b/processor/src/processors/account_transactions/account_transactions_model.rs
@@ -17,7 +17,10 @@ use crate::{
 };
 use ahash::AHashSet;
 use allocative_derive::Allocative;
-use aptos_indexer_processor_sdk::utils::convert::standardize_address;
+use aptos_indexer_processor_sdk::{
+    aptos_indexer_transaction_stream::utils::time::parse_timestamp,
+    utils::convert::standardize_address,
+};
 use aptos_protos::transaction::v1::{transaction::TxnData, write_set_change::Change, Transaction};
 use field_count::FieldCount;
 use parquet_derive::ParquetRecordWriter;
@@ -68,6 +71,8 @@ impl AccountTransaction {
                     }),
                     txn_version,
                     transaction.block_height as i64,
+                    parse_timestamp(transaction.timestamp.as_ref().unwrap(), txn_version)
+                        .naive_utc(),
                 ),
             ),
             TxnData::Genesis(inner) => (&inner.events, vec![]),

--- a/processor/src/processors/ans/ans_extractor.rs
+++ b/processor/src/processors/ans/ans_extractor.rs
@@ -245,7 +245,11 @@ pub fn parse_ans(
 
                             // Include all v1 lookups in v2 data
                             let (current_ans_lookup_v2, ans_lookup_v2) =
-                                CurrentAnsLookupV2::get_v2_from_v1(current_ans_lookup, ans_lookup);
+                                CurrentAnsLookupV2::get_v2_from_v1(
+                                    current_ans_lookup,
+                                    ans_lookup,
+                                    block_timestamp,
+                                );
                             all_current_ans_lookups_v2
                                 .insert(current_ans_lookup_v2.pk(), current_ans_lookup_v2);
                             all_ans_lookups_v2.push(ans_lookup_v2);
@@ -300,7 +304,11 @@ pub fn parse_ans(
 
                             // Include all v1 lookups in v2 data
                             let (current_ans_lookup_v2, ans_lookup_v2) =
-                                CurrentAnsLookupV2::get_v2_from_v1(current_ans_lookup, ans_lookup);
+                                CurrentAnsLookupV2::get_v2_from_v1(
+                                    current_ans_lookup,
+                                    ans_lookup,
+                                    block_timestamp,
+                                );
                             all_current_ans_lookups_v2
                                 .insert(current_ans_lookup_v2.pk(), current_ans_lookup_v2);
                             all_ans_lookups_v2.push(ans_lookup_v2);
@@ -340,6 +348,7 @@ pub fn parse_ans(
                                 txn_version,
                                 wsc_index as i64,
                                 &v2_address_to_subdomain_ext,
+                                block_timestamp,
                             )
                             .unwrap_or_else(|e| {
                                 error!(

--- a/processor/src/processors/user_transaction/models/signature_utils/account_signature_utils.rs
+++ b/processor/src/processors/user_transaction/models/signature_utils/account_signature_utils.rs
@@ -41,6 +41,7 @@ pub fn from_account_signature(
     is_sender_primary: bool,
     multi_agent_index: i64,
     override_address: Option<&String>, // Used to get proper signer in fee_payer_signature
+    block_timestamp: chrono::NaiveDateTime,
 ) -> Vec<Signature> {
     // Skip parsing if unknown signature is found.
     if s.signature.as_ref().is_none() {
@@ -64,6 +65,7 @@ pub fn from_account_signature(
             is_sender_primary,
             multi_agent_index,
             override_address,
+            block_timestamp,
         )],
         AccountSignatureEnum::MultiEd25519(sig) => parse_multi_ed25519_signature(
             sig,
@@ -74,6 +76,7 @@ pub fn from_account_signature(
             is_sender_primary,
             multi_agent_index,
             override_address,
+            block_timestamp,
         ),
         AccountSignatureEnum::SingleKeySignature(sig) => {
             vec![parse_single_key_signature(
@@ -85,6 +88,7 @@ pub fn from_account_signature(
                 is_sender_primary,
                 multi_agent_index,
                 override_address,
+                block_timestamp,
             )]
         },
         AccountSignatureEnum::MultiKeySignature(sig) => parse_multi_key_signature(
@@ -96,6 +100,7 @@ pub fn from_account_signature(
             is_sender_primary,
             multi_agent_index,
             override_address,
+            block_timestamp,
         ),
         AccountSignatureEnum::Abstraction(_sig) => {
             vec![parse_abstraction_signature(
@@ -106,6 +111,7 @@ pub fn from_account_signature(
                 is_sender_primary,
                 multi_agent_index,
                 override_address,
+                block_timestamp,
             )]
         },
     }
@@ -120,6 +126,7 @@ pub fn parse_single_key_signature(
     is_sender_primary: bool,
     multi_agent_index: i64,
     override_address: Option<&String>,
+    block_timestamp: chrono::NaiveDateTime,
 ) -> Signature {
     let signer = standardize_address(override_address.unwrap_or(sender));
     let any_signature = s.signature.as_ref().unwrap();
@@ -130,6 +137,7 @@ pub fn parse_single_key_signature(
     Signature {
         transaction_version,
         transaction_block_height,
+        block_timestamp,
         signer,
         is_sender_primary,
         account_signature_type: account_signature_type.to_string(),
@@ -156,6 +164,7 @@ pub fn parse_multi_key_signature(
     is_sender_primary: bool,
     multi_agent_index: i64,
     override_address: Option<&String>,
+    block_timestamp: chrono::NaiveDateTime,
 ) -> Vec<Signature> {
     let signer = standardize_address(override_address.unwrap_or(sender));
     let mut signatures = Vec::default();
@@ -173,6 +182,7 @@ pub fn parse_multi_key_signature(
         signatures.push(Signature {
             transaction_version,
             transaction_block_height,
+            block_timestamp,
             signer: signer.clone(),
             is_sender_primary,
             account_signature_type: account_signature_type.to_string(),
@@ -206,11 +216,13 @@ pub fn parse_abstraction_signature(
     is_sender_primary: bool,
     multi_agent_index: i64,
     override_address: Option<&String>,
+    block_timestamp: chrono::NaiveDateTime,
 ) -> Signature {
     let signer = standardize_address(override_address.unwrap_or(sender));
     Signature {
         transaction_version,
         transaction_block_height,
+        block_timestamp,
         signer,
         is_sender_primary,
         account_signature_type: account_signature_type.to_string(),

--- a/processor/src/processors/user_transaction/models/signatures.rs
+++ b/processor/src/processors/user_transaction/models/signatures.rs
@@ -101,6 +101,9 @@ impl From<Signature> for PostgresSignature {
 #[derive(Allocative, Clone, Debug, Default, Deserialize, ParquetRecordWriter, Serialize)]
 pub struct ParquetSignature {
     pub txn_version: i64,
+    pub multi_agent_index: i64,
+    pub multi_sig_index: i64,
+    pub is_sender_primary: bool,
     pub block_height: i64,
     pub signer: String,
     pub account_signature_type: String,
@@ -127,6 +130,9 @@ impl From<Signature> for ParquetSignature {
     fn from(raw: Signature) -> Self {
         ParquetSignature {
             txn_version: raw.transaction_version,
+            multi_agent_index: raw.multi_agent_index,
+            multi_sig_index: raw.multi_sig_index,
+            is_sender_primary: raw.is_sender_primary,
             block_height: raw.transaction_block_height,
             signer: raw.signer,
             account_signature_type: raw.account_signature_type,

--- a/processor/src/processors/user_transaction/models/signatures.rs
+++ b/processor/src/processors/user_transaction/models/signatures.rs
@@ -30,6 +30,7 @@ pub struct Signature {
     pub signature: String,
     pub threshold: i64,
     pub public_key_indices: serde_json::Value,
+    pub block_timestamp: chrono::NaiveDateTime,
 }
 
 impl Signature {
@@ -39,6 +40,7 @@ impl Signature {
         sender: &String,
         transaction_version: i64,
         transaction_block_height: i64,
+        block_timestamp: chrono::NaiveDateTime,
     ) -> Vec<Self> {
         from_parent_signature(
             s,
@@ -48,6 +50,7 @@ impl Signature {
             true,
             0,
             None,
+            block_timestamp,
         )
     }
 }
@@ -141,7 +144,7 @@ impl From<Signature> for ParquetSignature {
             public_key: raw.public_key,
             signature: raw.signature,
             threshold: Some(raw.threshold),
-            block_timestamp: chrono::NaiveDateTime::default(), // Need to populate separately
+            block_timestamp: raw.block_timestamp,
         }
     }
 }


### PR DESCRIPTION
### TL;DR

Added block timestamp to signature and Update ANS lookup v2 

### What changed?

- Added `block_timestamp` field to `Signature` and `AnsLookupV2` models
- Renamed `transaction_version` to `txn_version` in `ParquetAnsLookupV2` for consistency

### How to test?

![Screenshot 2025-03-12 at 3.04.51 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XVbPtMdqqe4K1PNnLQvf/40b9f92c-acca-4b73-8b8f-d31e4e107101.png)

![Screenshot 2025-03-12 at 2.56.16 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XVbPtMdqqe4K1PNnLQvf/b90974df-c037-407c-968c-c28ed926a575.png)

