### PR TITLE
support collections_v2 in parquet

### DIFF
--- a/processor/src/parquet_processors/mod.rs
+++ b/processor/src/parquet_processors/mod.rs
@@ -43,6 +43,7 @@ use crate::{
                 token_royalty::ParquetCurrentTokenRoyaltyV1,
             },
             token_v2_models::{
+                v2_collections::ParquetCollectionV2,
                 v2_token_activities::ParquetTokenActivityV2,
                 v2_token_datas::{ParquetCurrentTokenDataV2, ParquetTokenDataV2},
                 v2_token_metadata::ParquetCurrentTokenV2Metadata,
@@ -148,6 +149,7 @@ pub enum ParquetTypeEnum {
     CurrentTokenDatasV2,
     TokenOwnershipsV2,
     CurrentTokenOwnershipsV2,
+    CollectionsV2,
     // stake
     DelegatedStakingActivities,
     CurrentDelegatorBalances,
@@ -290,6 +292,7 @@ impl_parquet_trait!(ParquetDelegatorBalance, ParquetTypeEnum::DelegatorBalances)
 impl_parquet_trait!(ParquetProposalVote, ParquetTypeEnum::ProposalVotes);
 impl_parquet_trait!(ParquetObject, ParquetTypeEnum::Objects);
 impl_parquet_trait!(ParquetCurrentObject, ParquetTypeEnum::CurrentObjects);
+impl_parquet_trait!(ParquetCollectionV2, ParquetTypeEnum::CollectionsV2);
 
 #[derive(Debug, Clone)]
 #[enum_dispatch(ParquetTypeTrait)]
@@ -333,6 +336,7 @@ pub enum ParquetTypeStructs {
     CurrentTokenDataV2(Vec<ParquetCurrentTokenDataV2>),
     TokenOwnershipV2(Vec<ParquetTokenOwnershipV2>),
     CurrentTokenOwnershipV2(Vec<ParquetCurrentTokenOwnershipV2>),
+    CollectionV2(Vec<ParquetCollectionV2>),
     // Stake
     DelegatedStakingActivity(Vec<ParquetDelegatedStakingActivity>),
     CurrentDelegatorBalance(Vec<ParquetCurrentDelegatorBalance>),
@@ -417,6 +421,7 @@ impl ParquetTypeStructs {
             ParquetTypeEnum::ProposalVotes => ParquetTypeStructs::ProposalVote(Vec::new()),
             ParquetTypeEnum::Objects => ParquetTypeStructs::Object(Vec::new()),
             ParquetTypeEnum::CurrentObjects => ParquetTypeStructs::CurrentObject(Vec::new()),
+            ParquetTypeEnum::CollectionsV2 => ParquetTypeStructs::CollectionV2(Vec::new()),
         }
     }
 
@@ -644,6 +649,12 @@ impl ParquetTypeStructs {
             (
                 ParquetTypeStructs::CurrentObject(self_data),
                 ParquetTypeStructs::CurrentObject(other_data),
+            ) => {
+                handle_append!(self_data, other_data)
+            },
+            (
+                ParquetTypeStructs::CollectionV2(self_data),
+                ParquetTypeStructs::CollectionV2(other_data),
             ) => {
                 handle_append!(self_data, other_data)
             },

--- a/processor/src/parquet_processors/parquet_token_v2/parquet_token_v2_processor.rs
+++ b/processor/src/parquet_processors/parquet_token_v2/parquet_token_v2_processor.rs
@@ -19,6 +19,7 @@ use crate::{
                 token_royalty::ParquetCurrentTokenRoyaltyV1,
             },
             token_v2_models::{
+                v2_collections::ParquetCollectionV2,
                 v2_token_activities::ParquetTokenActivityV2,
                 v2_token_datas::{ParquetCurrentTokenDataV2, ParquetTokenDataV2},
                 v2_token_metadata::ParquetCurrentTokenV2Metadata,
@@ -159,6 +160,10 @@ impl ProcessorTrait for ParquetTokenV2Processor {
             (
                 ParquetTypeEnum::CurrentTokenOwnershipsV2,
                 ParquetCurrentTokenOwnershipV2::schema(),
+            ),
+            (
+                ParquetTypeEnum::CollectionsV2,
+                ParquetCollectionV2::schema(),
             ),
         ]
         .into_iter()

--- a/processor/src/processors/token_v2/token_v2_models/v2_token_ownerships.rs
+++ b/processor/src/processors/token_v2/token_v2_models/v2_token_ownerships.rs
@@ -375,11 +375,10 @@ impl TokenOwnershipV2 {
                     None => {
                         match db_context {
                             None => {
-                                // TODO: update message
-                                tracing::error!(
+                                tracing::debug!(
                                     transaction_version = txn_version,
                                     lookup_key = &token_address,
-                                    "Failed to find current_token_ownership_v2 for burned token. You probably should backfill db."
+                                    "Avoiding db lookup for Parquet."
                                 );
                                 DEFAULT_OWNER_ADDRESS.to_string()
                             },

--- a/processor/src/processors/token_v2/token_v2_processor_helpers.rs
+++ b/processor/src/processors/token_v2/token_v2_processor_helpers.rs
@@ -262,29 +262,23 @@ pub async fn parse_v2_token(
                 let wsc_index = index as i64;
                 match wsc.change.as_ref().unwrap() {
                     Change::WriteTableItem(table_item) => {
-                        // TODO: revisit when we migrate collection_v2 for parquet
-                        // for not it will be only handled for postgres
-                        if let Some(ref mut db_context) = db_context {
-                            if let Some((collection, current_collection)) =
-                                CollectionV2::get_v1_from_write_table_item(
-                                    table_item,
-                                    txn_version,
-                                    wsc_index,
-                                    txn_timestamp,
-                                    table_handle_to_owner,
-                                    &mut db_context.conn,
-                                    db_context.query_retries,
-                                    db_context.query_retry_delay_ms,
-                                )
-                                .await
-                                .unwrap()
-                            {
-                                collections_v2.push(collection);
-                                current_collections_v2.insert(
-                                    current_collection.collection_id.clone(),
-                                    current_collection,
-                                );
-                            }
+                        if let Some((collection, current_collection)) =
+                            CollectionV2::get_v1_from_write_table_item(
+                                table_item,
+                                txn_version,
+                                wsc_index,
+                                txn_timestamp,
+                                table_handle_to_owner,
+                                db_context,
+                            )
+                            .await
+                            .unwrap()
+                        {
+                            collections_v2.push(collection);
+                            current_collections_v2.insert(
+                                current_collection.collection_id.clone(),
+                                current_collection,
+                            );
                         }
 
                         if let Some((token_data, current_token_data)) =


### PR DESCRIPTION
### TL;DR

Added support for Collections V2 in the Parquet processor.

### What changed?

- Added `ParquetCollectionV2` struct to support serializing collection data to Parquet format



### How to test?


![Screenshot 2025-03-12 at 4.12.46 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XVbPtMdqqe4K1PNnLQvf/e872f60a-065c-4b88-bab6-b52c40254cf9.png)

