### PR TITLE
fix token activities parquet schema

### DIFF
--- a/processor/src/processors/token_v2/token_v2_models/v2_token_activities.rs
+++ b/processor/src/processors/token_v2/token_v2_models/v2_token_activities.rs
@@ -370,7 +370,7 @@ pub struct ParquetTokenActivityV2 {
     pub event_account_address: String,
     pub token_data_id: String,
     pub property_version_v1: u64, // BigDecimal
-    pub type_: String,
+    pub event_type: String,
     pub from_address: Option<String>,
     pub to_address: Option<String>,
     pub token_amount: String, // BigDecimal
@@ -401,7 +401,7 @@ impl From<TokenActivityV2> for ParquetTokenActivityV2 {
             event_account_address: raw_item.event_account_address,
             token_data_id: raw_item.token_data_id,
             property_version_v1: raw_item.property_version_v1.to_u64().unwrap(),
-            type_: raw_item.type_,
+            event_type: raw_item.type_,
             from_address: raw_item.from_address,
             to_address: raw_item.to_address,
             token_amount: raw_item.token_amount.to_string(),


### PR DESCRIPTION
### TL;DR

Renamed the `type_` field to `event_type` in the `ParquetTokenActivityV2` struct.

### What changed?

- Changed the field name from `type_` to `event_type` in the `ParquetTokenActivityV2` struct 
- during migration it changed to wrong column name causing Parquet qc pipeline failed. 