### PR TITLE
fix default processor v2

### DIFF
--- a/processor/src/processors/default/default_storer.rs
+++ b/processor/src/processors/default/default_storer.rs
@@ -259,6 +259,6 @@ pub fn insert_move_modules_query(
 
     diesel::insert_into(schema::move_modules::table)
         .values(items_to_insert)
-        .on_conflict(transaction_version)
+        .on_conflict((transaction_version, write_set_change_index))
         .do_nothing()
 }

--- a/processor/src/processors/default/models/move_modules.rs
+++ b/processor/src/processors/default/models/move_modules.rs
@@ -118,24 +118,30 @@ impl MoveModule {
             address: standardize_address(&move_module.address.to_string()),
             name: move_module.name.clone(),
             bytecode,
-            exposed_functions: move_module
-                .exposed_functions
-                .iter()
-                .map(|move_func| serde_json::to_value(move_func).unwrap())
-                .map(|value| canonical_json::to_string(&value).unwrap())
-                .collect(),
-            friends: move_module
-                .friends
-                .iter()
-                .map(|move_module_id| serde_json::to_value(move_module_id).unwrap())
-                .map(|value| canonical_json::to_string(&value).unwrap())
-                .collect(),
-            structs: move_module
-                .structs
-                .iter()
-                .map(|move_struct| serde_json::to_value(move_struct).unwrap())
-                .map(|value| canonical_json::to_string(&value).unwrap())
-                .collect(),
+            exposed_functions: canonical_json::to_string(&serde_json::Value::Array(
+                move_module
+                    .exposed_functions
+                    .iter()
+                    .map(|move_func| serde_json::to_value(move_func).unwrap())
+                    .collect(),
+            ))
+            .unwrap(),
+            friends: canonical_json::to_string(&serde_json::Value::Array(
+                move_module
+                    .friends
+                    .iter()
+                    .map(|move_module_id| serde_json::to_value(move_module_id).unwrap())
+                    .collect(),
+            ))
+            .unwrap(),
+            structs: canonical_json::to_string(&serde_json::Value::Array(
+                move_module
+                    .structs
+                    .iter()
+                    .map(|move_struct| serde_json::to_value(move_struct).unwrap())
+                    .collect(),
+            ))
+            .unwrap(),
         }
     }
 }


### PR DESCRIPTION
### Description

We added move module back to Postgres processor, and it had an issue with json serialization for move module, where we were converting each function to JSON string individually and collecting them, which resulted in concatenated strings like {"name":"add"}{"name":"remove"}

Fix is we first collect all functions into a Vec of <JSON Value>, then wrap them in a JSON array before converting to string, which gives us proper JSON array like [{"name":"add"},{"name":"remove"}]


Also, fixed a database conflict issue in move modules by using correct primary key.

### How to test?
locally tested with failing txn. 

