### PR TITLE
fix query to not create a duplicated row

### DIFF
--- a/processor/src/processors/token_v2/token_v2_models/v2_token_ownerships.rs
+++ b/processor/src/processors/token_v2/token_v2_models/v2_token_ownerships.rs
@@ -646,6 +646,7 @@ impl CurrentTokenOwnershipV2Query {
                 },
             }
         }
+        // This is unreachable because the loop will always return or error. it's here to satisfy the compiler.
         Err(anyhow::anyhow!(
             "Failed to get nft by token data id: {}",
             token_data_id
@@ -658,7 +659,6 @@ impl CurrentTokenOwnershipV2Query {
     ) -> diesel::QueryResult<Self> {
         current_token_ownerships_v2::table
             .filter(current_token_ownerships_v2::token_data_id.eq(token_data_id))
-            .filter(current_token_ownerships_v2::amount.gt(BigDecimal::zero()))
             .first::<Self>(conn)
             .await
     }


### PR DESCRIPTION
### Description
context: https://aptos-org.slack.com/archives/C03MN5F7WUV/p1750437337657149


when backfill started, it failed. 
![Screenshot 2025-06-24 at 9.22.44 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XVbPtMdqqe4K1PNnLQvf/9a1d1dbc-8c9a-4bf5-8e91-0af7a8fd5301.png)

added previous txn contains this value
![Screenshot 2025-06-24 at 9.21.56 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XVbPtMdqqe4K1PNnLQvf/e081b838-6874-43c1-a043-8ba0221ad673.png)

and reran it didn't fail to get row and add new row with default value. 
