### PR TITLE
standardize deleted store addresses

### DIFF
--- a/processor/src/processors/fungible_asset/fungible_asset_models/v2_fungible_asset_activities.rs
+++ b/processor/src/processors/fungible_asset/fungible_asset_models/v2_fungible_asset_activities.rs
@@ -138,8 +138,10 @@ impl FungibleAssetActivity {
                         store_address_to_deleted_fa_store_events.get(&storage_id);
                     match deleted_fa_store_event {
                         Some(deleted_fa_store_event) => {
-                            maybe_owner_address = Some(deleted_fa_store_event.owner.clone());
-                            maybe_asset_type = Some(deleted_fa_store_event.metadata.clone());
+                            maybe_owner_address =
+                                Some(standardize_address(&deleted_fa_store_event.owner));
+                            maybe_asset_type =
+                                Some(standardize_address(&deleted_fa_store_event.metadata));
                         },
                         None => {
                             // There might not be a deletion event if the transaction was committed before FungibleStoreDeletion


### PR DESCRIPTION
Standardize the addresses from `0x1::fungible_asset::FungibleStoreDeletion` event

![Screenshot 2025-06-30 at 5.25.41 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/vIwavW9noSx0eb70aDLz/659af43e-5347-4da4-b2da-1d5daf27fb24.png)

