### PR TITLE
remove fa legacy table from parquet fa processor

### DIFF
--- a/processor/src/config/processor_config.rs
+++ b/processor/src/config/processor_config.rs
@@ -28,10 +28,8 @@ use crate::{
         events::events_model::ParquetEvent,
         fungible_asset::fungible_asset_models::{
             v2_fungible_asset_activities::ParquetFungibleAssetActivity,
-            v2_fungible_asset_balances::{
-                ParquetCurrentFungibleAssetBalance, ParquetCurrentUnifiedFungibleAssetBalance,
-                ParquetFungibleAssetBalance,
-            },
+            v2_fungible_asset_balances::ParquetFungibleAssetBalance,
+            v2_fungible_asset_to_coin_mappings::ParquetFungibleAssetToCoinMapping,
             v2_fungible_metadata::ParquetFungibleAssetMetadataModel,
         },
         objects::{
@@ -205,9 +203,8 @@ impl ProcessorConfig {
             ProcessorName::ParquetFungibleAssetProcessor => HashSet::from([
                 ParquetFungibleAssetActivity::TABLE_NAME.to_string(),
                 ParquetFungibleAssetBalance::TABLE_NAME.to_string(),
-                ParquetCurrentFungibleAssetBalance::TABLE_NAME.to_string(),
-                ParquetCurrentUnifiedFungibleAssetBalance::TABLE_NAME.to_string(),
                 ParquetFungibleAssetMetadataModel::TABLE_NAME.to_string(),
+                ParquetFungibleAssetToCoinMapping::TABLE_NAME.to_string(),
             ]),
             ProcessorName::ParquetTransactionMetadataProcessor => {
                 HashSet::from([ParquetWriteSetSize::TABLE_NAME.to_string()])

--- a/processor/src/parquet_processors/mod.rs
+++ b/processor/src/parquet_processors/mod.rs
@@ -24,10 +24,7 @@ use crate::{
         events::events_model::ParquetEvent,
         fungible_asset::fungible_asset_models::{
             v2_fungible_asset_activities::ParquetFungibleAssetActivity,
-            v2_fungible_asset_balances::{
-                ParquetCurrentFungibleAssetBalance, ParquetCurrentUnifiedFungibleAssetBalance,
-                ParquetFungibleAssetBalance,
-            },
+            v2_fungible_asset_balances::ParquetFungibleAssetBalance,
             v2_fungible_asset_to_coin_mappings::ParquetFungibleAssetToCoinMapping,
             v2_fungible_metadata::ParquetFungibleAssetMetadataModel,
         },
@@ -134,7 +131,6 @@ pub enum ParquetTypeEnum {
     FungibleAssetMetadata,
     FungibleAssetBalances,
     CurrentFungibleAssetBalances,
-    CurrentFungibleAssetBalancesLegacy,
     FungibleAssetToCoinMappings,
     // txn metadata,
     WriteSetSize,
@@ -240,14 +236,6 @@ impl_parquet_trait!(
     ParquetTypeEnum::FungibleAssetBalances
 );
 impl_parquet_trait!(
-    ParquetCurrentUnifiedFungibleAssetBalance,
-    ParquetTypeEnum::CurrentFungibleAssetBalances
-);
-impl_parquet_trait!(
-    ParquetCurrentFungibleAssetBalance,
-    ParquetTypeEnum::CurrentFungibleAssetBalancesLegacy
-);
-impl_parquet_trait!(
     ParquetFungibleAssetToCoinMapping,
     ParquetTypeEnum::FungibleAssetToCoinMappings
 );
@@ -320,8 +308,7 @@ pub enum ParquetTypeStructs {
     FungibleAssetActivity(Vec<ParquetFungibleAssetActivity>),
     FungibleAssetMetadata(Vec<ParquetFungibleAssetMetadataModel>),
     FungibleAssetBalance(Vec<ParquetFungibleAssetBalance>),
-    CurrentFungibleAssetBalance(Vec<ParquetCurrentFungibleAssetBalance>),
-    CurrentUnifiedFungibleAssetBalance(Vec<ParquetCurrentUnifiedFungibleAssetBalance>),
+    // CurrentUnifiedFungibleAssetBalance(Vec<ParquetCurrentUnifiedFungibleAssetBalance>),
     FungibleAssetToCoinMappings(Vec<ParquetFungibleAssetToCoinMapping>),
     // Txn metadata
     WriteSetSize(Vec<ParquetWriteSetSize>),
@@ -379,9 +366,6 @@ impl ParquetTypeStructs {
             },
             ParquetTypeEnum::FungibleAssetBalances => {
                 ParquetTypeStructs::FungibleAssetBalance(Vec::new())
-            },
-            ParquetTypeEnum::CurrentFungibleAssetBalancesLegacy => {
-                ParquetTypeStructs::CurrentFungibleAssetBalance(Vec::new())
             },
             ParquetTypeEnum::CurrentFungibleAssetBalances => {
                 ParquetTypeStructs::CurrentUnifiedFungibleAssetBalance(Vec::new())
@@ -513,12 +497,6 @@ impl ParquetTypeStructs {
             (
                 ParquetTypeStructs::FungibleAssetBalance(self_data),
                 ParquetTypeStructs::FungibleAssetBalance(other_data),
-            ) => {
-                handle_append!(self_data, other_data)
-            },
-            (
-                ParquetTypeStructs::CurrentFungibleAssetBalance(self_data),
-                ParquetTypeStructs::CurrentFungibleAssetBalance(other_data),
             ) => {
                 handle_append!(self_data, other_data)
             },

--- a/processor/src/parquet_processors/mod.rs
+++ b/processor/src/parquet_processors/mod.rs
@@ -130,7 +130,6 @@ pub enum ParquetTypeEnum {
     FungibleAssetActivities,
     FungibleAssetMetadata,
     FungibleAssetBalances,
-    CurrentFungibleAssetBalances,
     FungibleAssetToCoinMappings,
     // txn metadata,
     WriteSetSize,
@@ -308,7 +307,6 @@ pub enum ParquetTypeStructs {
     FungibleAssetActivity(Vec<ParquetFungibleAssetActivity>),
     FungibleAssetMetadata(Vec<ParquetFungibleAssetMetadataModel>),
     FungibleAssetBalance(Vec<ParquetFungibleAssetBalance>),
-    // CurrentUnifiedFungibleAssetBalance(Vec<ParquetCurrentUnifiedFungibleAssetBalance>),
     FungibleAssetToCoinMappings(Vec<ParquetFungibleAssetToCoinMapping>),
     // Txn metadata
     WriteSetSize(Vec<ParquetWriteSetSize>),
@@ -366,9 +364,6 @@ impl ParquetTypeStructs {
             },
             ParquetTypeEnum::FungibleAssetBalances => {
                 ParquetTypeStructs::FungibleAssetBalance(Vec::new())
-            },
-            ParquetTypeEnum::CurrentFungibleAssetBalances => {
-                ParquetTypeStructs::CurrentUnifiedFungibleAssetBalance(Vec::new())
             },
             ParquetTypeEnum::FungibleAssetToCoinMappings => {
                 ParquetTypeStructs::FungibleAssetToCoinMappings(Vec::new())
@@ -497,12 +492,6 @@ impl ParquetTypeStructs {
             (
                 ParquetTypeStructs::FungibleAssetBalance(self_data),
                 ParquetTypeStructs::FungibleAssetBalance(other_data),
-            ) => {
-                handle_append!(self_data, other_data)
-            },
-            (
-                ParquetTypeStructs::CurrentUnifiedFungibleAssetBalance(self_data),
-                ParquetTypeStructs::CurrentUnifiedFungibleAssetBalance(other_data),
             ) => {
                 handle_append!(self_data, other_data)
             },

--- a/processor/src/parquet_processors/parquet_fungible_asset/parquet_fa_extractor.rs
+++ b/processor/src/parquet_processors/parquet_fungible_asset/parquet_fa_extractor.rs
@@ -27,7 +27,6 @@ use aptos_indexer_processor_sdk::{
 };
 use async_trait::async_trait;
 use std::collections::HashMap;
-use tracing::debug;
 
 /// Extracts parquet data from transactions, allowing optional selection of specific tables.
 pub struct ParquetFungibleAssetExtractor
@@ -103,25 +102,6 @@ impl Processable for ParquetFungibleAssetExtractor {
                 .into_iter()
                 .map(ParquetFungibleAssetToCoinMapping::from)
                 .collect();
-
-        // Print the size of each extracted data type
-        debug!("Processed data sizes:");
-        debug!(
-            " - V2FungibleAssetActivity: {}",
-            parquet_fungible_asset_activities.len()
-        );
-        debug!(
-            " - V2FungibleAssetMetadata: {}",
-            parquet_fungible_asset_metadata.len()
-        );
-        debug!(
-            " - V2FungibleAssetBalance: {}",
-            parquet_fungible_asset_balances.len()
-        );
-        debug!(
-            " - V2FungibleAssetToCoinMapping: {}",
-            parquet_fa_to_coin_mappings.len()
-        );
 
         let mut map: HashMap<ParquetTypeEnum, ParquetTypeStructs> = HashMap::new();
 

--- a/processor/src/parquet_processors/parquet_fungible_asset/parquet_fungible_asset_processor.rs
+++ b/processor/src/parquet_processors/parquet_fungible_asset/parquet_fungible_asset_processor.rs
@@ -16,10 +16,7 @@ use crate::{
     },
     processors::fungible_asset::fungible_asset_models::{
         v2_fungible_asset_activities::ParquetFungibleAssetActivity,
-        v2_fungible_asset_balances::{
-            ParquetCurrentFungibleAssetBalance, ParquetCurrentUnifiedFungibleAssetBalance,
-            ParquetFungibleAssetBalance,
-        },
+        v2_fungible_asset_balances::ParquetFungibleAssetBalance,
         v2_fungible_asset_to_coin_mappings::ParquetFungibleAssetToCoinMapping,
         v2_fungible_metadata::ParquetFungibleAssetMetadataModel,
     },
@@ -131,14 +128,6 @@ impl ProcessorTrait for ParquetFungibleAssetProcessor {
             (
                 ParquetTypeEnum::FungibleAssetBalances,
                 ParquetFungibleAssetBalance::schema(),
-            ),
-            (
-                ParquetTypeEnum::CurrentFungibleAssetBalancesLegacy,
-                ParquetCurrentFungibleAssetBalance::schema(),
-            ),
-            (
-                ParquetTypeEnum::CurrentFungibleAssetBalances,
-                ParquetCurrentUnifiedFungibleAssetBalance::schema(),
             ),
             (
                 ParquetTypeEnum::FungibleAssetToCoinMappings,

--- a/processor/src/processors/fungible_asset/fungible_asset_models/v2_fungible_asset_balances.rs
+++ b/processor/src/processors/fungible_asset/fungible_asset_models/v2_fungible_asset_balances.rs
@@ -444,33 +444,6 @@ impl From<FungibleAssetBalance> for ParquetFungibleAssetBalance {
 #[derive(
     Allocative, Clone, Debug, Default, Deserialize, FieldCount, ParquetRecordWriter, Serialize,
 )]
-pub struct ParquetCurrentFungibleAssetBalance {
-    pub storage_id: String,
-    pub owner_address: String,
-    pub asset_type: String,
-    pub is_primary: bool,
-    pub is_frozen: bool,
-    pub amount: String, // it is a string representation of the u128
-    pub last_transaction_version: i64,
-    #[allocative(skip)]
-    pub last_transaction_timestamp: chrono::NaiveDateTime,
-    pub token_standard: String,
-}
-
-impl NamedTable for ParquetCurrentFungibleAssetBalance {
-    const TABLE_NAME: &'static str = "current_fungible_asset_balances_legacy";
-}
-
-impl HasVersion for ParquetCurrentFungibleAssetBalance {
-    fn version(&self) -> i64 {
-        self.last_transaction_version
-    }
-}
-/// Note that this used to be called current_unified_fungible_asset_balances_to_be_renamed
-/// and was renamed to current_fungible_asset_balances to facilitate migration
-#[derive(
-    Allocative, Clone, Debug, Default, Deserialize, FieldCount, ParquetRecordWriter, Serialize,
-)]
 pub struct ParquetCurrentUnifiedFungibleAssetBalance {
     pub storage_id: String,
     pub owner_address: String,


### PR DESCRIPTION
### Description
The `current_fungible_asset_balances_legacy` table was included in the logic that determines the starting version for Parquet processing. However, since this table hasn’t recorded any transactions since Jan 2025, it caused the new deployment to incorrectly pick up an outdated starting version.
To resolve this, the table was removed from the Parquet fungible asset processor logic.
