### PR TITLE
Uncomment index creation for devnet reset 

### DIFF
--- a/processor/src/db/migrations/2025-01-07-000504_add_function_columns_to_user_transactions/up.sql
+++ b/processor/src/db/migrations/2025-01-07-000504_add_function_columns_to_user_transactions/up.sql
@@ -5,4 +5,4 @@ ADD COLUMN entry_function_module_name VARCHAR(255),
 ADD COLUMN entry_function_function_name VARCHAR(255);
 
 -- If you would like to run these indices, please do it outside of diesel migration since it will be blocking processing
--- CREATE INDEX CONCURRENTLY IF NOT EXISTS user_transactions_contract_info_index ON user_transactions (entry_function_contract_address, version);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS user_transactions_contract_info_index ON user_transactions (entry_function_contract_address, entry_function_module_name, entry_function_function_name);

--- a/processor/src/db/migrations/2025-01-07-000504_add_function_columns_to_user_transactions/up.sql
+++ b/processor/src/db/migrations/2025-01-07-000504_add_function_columns_to_user_transactions/up.sql
@@ -5,4 +5,4 @@ ADD COLUMN entry_function_module_name VARCHAR(255),
 ADD COLUMN entry_function_function_name VARCHAR(255);
 
 -- If you would like to run these indices, please do it outside of diesel migration since it will be blocking processing
-CREATE INDEX CONCURRENTLY IF NOT EXISTS user_transactions_contract_info_index ON user_transactions (entry_function_contract_address, entry_function_module_name, entry_function_function_name);
+CREATE INDEX IF NOT EXISTS user_transactions_contract_info_index ON user_transactions (entry_function_contract_address, entry_function_module_name, entry_function_function_name);


### PR DESCRIPTION
During devnet reset, the DB migration gets applied to a fresh DB and some queries need this index. This should be safe because anyone running the core processors should have already applied this migration.