### PR TITLE
Update jemalloc to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2443,11 +2443,9 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 [[package]]
 name = "jemalloc-sys"
 version = "0.5.4+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
+source = "git+https://github.com/aptos-labs/jemalloc-sys-shim?rev=e0920246dd74303fab9a14b990768c6ac990a59b#e0920246dd74303fab9a14b990768c6ac990a59b"
 dependencies = [
- "cc",
- "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]
@@ -3462,7 +3460,6 @@ dependencies = [
  "hex",
  "hyper 0.14.32",
  "itertools 0.12.1",
- "jemallocator",
  "lazy_static",
  "log",
  "native-tls",
@@ -3480,6 +3477,7 @@ dependencies = [
  "sha2 0.10.8",
  "sha3",
  "strum",
+ "tikv-jemallocator",
  "tiny-keccak",
  "tokio",
  "tokio-postgres",
@@ -4823,6 +4821,26 @@ dependencies = [
  "byteorder",
  "integer-encoding",
  "ordered-float 2.10.1",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,3 +135,7 @@ tracing-subscriber = { version = "0.3.17", features = ["json", "env-filter"] }
 unescape = "0.1.0"
 url = { version = "2.4.0", features = ["serde"] }
 warp = { version = "0.3.5", features = ["tls"] }
+
+[patch.crates-io]
+# Can be removed once the dependencies on aptos-core and aptos-indexer-processor-sdk have been updated (so we stop pulling any old jemalloc-sys).
+jemalloc-sys = { git = "https://github.com/aptos-labs/jemalloc-sys-shim", rev = "e0920246dd74303fab9a14b990768c6ac990a59b" }

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -75,8 +75,9 @@ unescape = { workspace = true }
 url = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-jemallocator = { version = "0.5.0", features = [
+jemallocator = { package = "tikv-jemallocator", version = "0.6.0", features = [
     "profiling",
+    "stats",
     "unprefixed_malloc_on_supported_platforms",
 ] }
 


### PR DESCRIPTION

This is similar to https://github.com/aptos-labs/aptos-core/pull/17446. See that
PR for more details.

Similarly, we have to use a shim until everything is updated. Right now this
repo still depends on an old version of `aptos-indexer-processor-sdk`, which in
turn depends on an old version of `aptos-core`, and that pulls in
`jemalloc-sys 0.5`, which is incompatible with `tikv-jemalloc-sys 0.6`.
