### PR TITLE
Update Hasura metadata to have ANS join for confidential assets activities

### DIFF
--- a/hasura-api/metadata-json/metadata.json
+++ b/hasura-api/metadata-json/metadata.json
@@ -162,6 +162,38 @@
                 }
               }
             ],
+            "array_relationships": [
+              {
+                "name": "owner_aptos_names",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "owner_address": "registered_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "counterparty_aptos_names",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "counterparty_address": "registered_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
             "select_permissions": [
               {
                 "role": "anonymous",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: metadata-only change that adds new GraphQL relationships without altering database schema or permission logic, but could affect query shapes/performance via additional joins.
> 
> **Overview**
> Adds two new Hasura `array_relationships` on `confidential_asset_activities` to join `owner_address` and `counterparty_address` to `current_aptos_names` (via `registered_address`), enabling ANS name data to be fetched alongside confidential asset activity rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66ef2cce5f3b26fdd4f682e9bda7129d7f05c580. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->