### PR TITLE
Add composite index for user_transactions function filter

### DIFF
--- a/processor/src/db/migrations/2026-05-12-000000_user_transactions_function_filter_index/down.sql
+++ b/processor/src/db/migrations/2026-05-12-000000_user_transactions_function_filter_index/down.sql
@@ -1,0 +1,8 @@
+-- Revert to the previous (contract_address, version) index.
+
+DROP INDEX IF EXISTS user_transactions_function_filter_index;
+
+CREATE INDEX user_transactions_contract_info_index ON user_transactions (
+  entry_function_contract_address,
+  version
+);

--- a/processor/src/db/migrations/2026-05-12-000000_user_transactions_function_filter_index/up.sql
+++ b/processor/src/db/migrations/2026-05-12-000000_user_transactions_function_filter_index/up.sql
@@ -1,0 +1,22 @@
+-- Replace the existing (contract_address, version) index with a composite
+-- that covers all three function-filter query patterns the explorer uses:
+--   1. WHERE contract_address = ?                          ORDER BY version DESC
+--   2. WHERE contract_address = ? AND module_name = ?      ORDER BY version DESC
+--   3. WHERE contract_address = ? AND module_name = ? AND function_name = ?
+--                                                          ORDER BY version DESC
+--
+-- Including version DESC as the trailing column lets Postgres satisfy both
+-- the filter and the sort from the index alone (no separate sort step).
+--
+-- Run by hand with CONCURRENTLY before running this migration on large pre-existing tables to avoid blocking writes:
+--   CREATE INDEX CONCURRENTLY user_transactions_function_filter_index ...
+--   DROP INDEX CONCURRENTLY user_transactions_contract_info_index;
+
+DROP INDEX IF EXISTS user_transactions_contract_info_index;
+
+CREATE INDEX user_transactions_function_filter_index ON user_transactions (
+  entry_function_contract_address,
+  entry_function_module_name,
+  entry_function_function_name,
+  version DESC
+);


### PR DESCRIPTION
Replace the (contract_address, version) index with a four-column composite (contract_address, module_name, function_name, version DESC) so the explorer's entry-function filter queries can use the index for all three granularities (address-only, address+module, full triple) while still satisfying ORDER BY version DESC from the index.

The migration contains plain CREATE/DROP INDEX statements. On production, run CREATE INDEX CONCURRENTLY / DROP INDEX CONCURRENTLY by hand to avoid blocking writes on this large table.

Co-authored-by: Cursor <cursoragent@cursor.com>
