### PR TITLE
Fix lints

### DIFF
--- a/processor/src/parquet_processors/parquet_utils/parquet_version_tracker_step.rs
+++ b/processor/src/parquet_processors/parquet_utils/parquet_version_tracker_step.rs
@@ -98,7 +98,7 @@ where
                 return Err(ProcessorError::ProcessError {
                     message: format!(
                         "Gap detected for {:?} starting from version: {}",
-                        &parquet_type.to_string(),
+                        parquet_type.to_string(),
                         current_metadata.start_version
                     ),
                 });

--- a/processor/src/processors/ans/models/ans_utils.rs
+++ b/processor/src/processors/ans/models/ans_utils.rs
@@ -43,9 +43,9 @@ pub struct OptionalBigDecimal {
 pub fn get_token_name(domain_name: &str, subdomain_name: &str) -> String {
     let domain = truncate_str(domain_name, DOMAIN_LENGTH);
     let subdomain = truncate_str(subdomain_name, DOMAIN_LENGTH);
-    let mut token_name = format!("{}.apt", &domain);
+    let mut token_name = format!("{}.apt", domain);
     if !subdomain.is_empty() {
-        token_name = format!("{}.{}", &subdomain, token_name);
+        token_name = format!("{}.{}", subdomain, token_name);
     }
     token_name
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Purely mechanical formatting/lint cleanups (removes unnecessary borrows in `format!` calls) with no behavioral changes expected.
> 
> **Overview**
> Removes unnecessary string borrows in a couple of `format!` usages to satisfy Rust lints.
> 
> This touches the parquet version-gap error message in `parquet_version_tracker_step.rs` and token-name construction in `ans_utils.rs`, without changing the underlying logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ab04b9f68953c1cc142ab8414e8d84fa507a5a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->