### PR TITLE
ci: harden GitHub Actions workflows (zizmor audit)

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -25,7 +25,9 @@ jobs:
   Build:
     runs-on: runs-on,cpu=16,family=c7,disk=large,image=ubuntu22-full-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/docker-setup
         with:
           GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
@@ -35,7 +37,7 @@ jobs:
         run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
         id: extract_branch
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/copy-processor-images-to-dockerhub.yaml
+++ b/.github/workflows/copy-processor-images-to-dockerhub.yaml
@@ -6,14 +6,17 @@ on:
 
 permissions:
   contents: read
-  id-token: write #required for GCP Workload Identity federation
 
 jobs:
   lint-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install Dependencies and Run Linter
         uses: ./.github/actions/dep_install_and_lint
@@ -28,8 +31,13 @@ jobs:
     # Run on a machine with more local storage for large docker images
     runs-on: ubuntu-latest
     needs: lint-test
+    permissions:
+      contents: read
+      id-token: write # required for GCP Workload Identity federation
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
 
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:
@@ -37,12 +45,12 @@ jobs:
           GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # pin@v2
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.ENV_DOCKERHUB_USERNAME }}
           password: ${{ secrets.ENV_DOCKERHUB_PASSWORD }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: .node-version
 
@@ -59,5 +67,6 @@ jobs:
           FORCE_COLOR: 3 # Force color output as per https://github.com/google/zx#using-github-actions
           GIT_SHA: ${{ github.sha }}
           GCP_DOCKER_ARTIFACT_REPO: ${{ vars.GCP_DOCKER_ARTIFACT_REPO }}
-        run: pnpm release-processor-images --language=rust --version-tag=${{ github.ref_name }} --wait-for-image-seconds=3600
+          VERSION_TAG: ${{ github.ref_name }}
+        run: pnpm release-processor-images --language=rust --version-tag="$VERSION_TAG" --wait-for-image-seconds=3600
         working-directory: scripts

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -15,14 +15,20 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   Integration-tests:
     runs-on: runs-on,runner=2cpu-linux-x64,run-id=${{ github.run_id }}
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
           ref: ${{ github.head_ref }} # check out the code from the pull request branch:
 
       # Install toml-cli using cargo
@@ -36,17 +42,18 @@ jobs:
       # Update aptos-system-utils dependency using toml-cli
       - name: Update aptos-system-utils dependency
         if: ${{ github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' }}
+        env:
+          COMMIT_HASH: ${{ github.event.client_payload.commit_hash || github.event.inputs.commit_hash }}
         run: |
-          COMMIT_HASH=${{ github.event.client_payload.commit_hash || github.event.inputs.commit_hash }}
           echo "Updating aptos-system-utils dependency in Cargo.toml to use commit hash $COMMIT_HASH"
           toml set Cargo.toml workspace.dependencies.aptos-system-utils.rev "$COMMIT_HASH" > Cargo.tmp && mv Cargo.tmp Cargo.toml
 
       # Update aptos-indexer-test-transactions dependency using toml-cli
       - name: Update aptos-indexer-test-transactions dependency
         if: ${{ github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' }}
+        env:
+          COMMIT_HASH: ${{ github.event.client_payload.commit_hash || github.event.inputs.commit_hash }}
         run: |
-          COMMIT_HASH=${{ github.event.client_payload.commit_hash || github.event.inputs.commit_hash }}
-
           echo "Updating aptos-indexer-test-transactions dependency in Cargo.toml to use commit hash $COMMIT_HASH"
           toml set Cargo.toml workspace.dependencies.aptos-indexer-test-transactions.rev "$COMMIT_HASH" > Cargo.tmp && mv Cargo.tmp Cargo.toml
 
@@ -63,7 +70,7 @@ jobs:
 
       # Cache Cargo
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/bin/
@@ -97,7 +104,7 @@ jobs:
 
       - name: Send Slack Notification to oncall
         if: ${{ steps.sanity-check.outcome == 'failure' && github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'indexer-sdk-update') }}
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
         with:
           # eco-infra-oncall channel.
           channel-id: 'C0468USBLQJ'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,20 +14,31 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.sha || github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   License-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Check license headers
         run: python3 scripts/check_license.py --check
 
   Rust:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       # Ensures to use the Rust toolchain version
-      - uses: dsherret/rust-toolchain-file@v1
+      - uses: dsherret/rust-toolchain-file@3551321aa44dd44a0393eb3b6bdfbc5d25ecf621 # v1
       - name: Install deps and run linter
         run: |
           sudo apt update && sudo apt install libdw-dev protobuf-compiler

--- a/.github/workflows/nightly-integration-tests.yaml
+++ b/.github/workflows/nightly-integration-tests.yaml
@@ -5,14 +5,21 @@ on:
   schedule:
     - cron: '0 9 * * *'  # This runs the workflow every day at 9:00 AM UTC
 
+permissions:
+  contents: read
+
 jobs:
 
   nightly-run:
     runs-on: runs-on,runner=2cpu-linux-x64,run-id=${{ github.run_id }}
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install Dependencies and Run Linter
         uses: ./.github/actions/dep_install_and_lint

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -21,13 +21,19 @@ concurrency:
   group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.ref) || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   rust-unit-coverage:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
 
       - name: rust setup
@@ -53,7 +59,7 @@ jobs:
         working-directory: .
       - run: ls -R
         working-directory: .
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: lcov_unit
           path: ./lcov_unit.info
@@ -61,17 +67,21 @@ jobs:
   upload-to-codecov:
     runs-on: ubuntu-latest
     continue-on-error: true # Don't fail if the codecov upload fails
+    permissions:
+      contents: read
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     needs: [ rust-unit-coverage ]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: lcov_unit
       - run: ls -R
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: lcov_unit.info
 #          fail_ci_if_error: true

--- a/.github/workflows/update-sdk-dependency.yaml
+++ b/.github/workflows/update-sdk-dependency.yaml
@@ -24,44 +24,44 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: auth
-        uses: "google-github-actions/auth@v2"
+        uses: "google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed" # v2
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
       - name: Get Secret Manager Secrets
         id: secrets
-        uses: 'google-github-actions/get-secretmanager-secrets@v2'
+        uses: 'google-github-actions/get-secretmanager-secrets@2b5f97c5a4b9c105e64646762ad4fc3f5128e6f5' # v2
         with:
           secrets: |-
             token:aptos-ci/github-actions-repository-dispatch
       - run: sudo apt-get update && sudo apt-get install build-essential ca-certificates clang curl git libpq-dev libssl-dev pkg-config lsof lld libdw-dev --no-install-recommends --assume-yes
         shell: bash
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
           token: ${{ steps.secrets.outputs.token }}
       - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
         with:
           rustflags: --cfg tokio_unstable
           components: cargo clippy rustc rust-docs rust-std
       - name: Install toml
         run: cargo install toml-cli
       - name: Update the dependency
+        env:
+          COMMIT_HASH: ${{ github.event.inputs.commit_hash || github.event.client_payload.commit_hash }}
+          APTOS_PROTOS_COMMIT_HASH: ${{ github.event.inputs.aptos_protos_commit_hash || github.event.client_payload.aptos_protos_commit_hash }}
+          BRANCH_NAME: ${{ github.event.inputs.branch_name || github.event.client_payload.branch_name }}
         run: |
           set -e
-          # Use workflow_dispatch inputs if available, otherwise use repository_dispatch values
-          commit_hash="${{ github.event.inputs.commit_hash || github.event.client_payload.commit_hash }}"
-          aptos_protos_commit_hash="${{ github.event.inputs.aptos_protos_commit_hash || github.event.client_payload.aptos_protos_commit_hash }}"
-          branch_name="${{ github.event.inputs.branch_name || github.event.client_payload.branch_name }}"
-          
           # SDK commit hash SDK + framework + testing.
-          toml set Cargo.toml workspace.dependencies.aptos-indexer-processor-sdk.rev "$commit_hash" > Cargo.tmp && mv Cargo.tmp Cargo.toml
-          toml set Cargo.toml workspace.dependencies.aptos-indexer-processor-sdk-server-framework.rev "$commit_hash" > Cargo.tmp && mv Cargo.tmp Cargo.toml
-          toml set Cargo.toml workspace.dependencies.aptos-indexer-testing-framework.rev "$commit_hash" > Cargo.tmp && mv Cargo.tmp Cargo.toml
+          toml set Cargo.toml workspace.dependencies.aptos-indexer-processor-sdk.rev "$COMMIT_HASH" > Cargo.tmp && mv Cargo.tmp Cargo.toml
+          toml set Cargo.toml workspace.dependencies.aptos-indexer-processor-sdk-server-framework.rev "$COMMIT_HASH" > Cargo.tmp && mv Cargo.tmp Cargo.toml
+          toml set Cargo.toml workspace.dependencies.aptos-indexer-testing-framework.rev "$COMMIT_HASH" > Cargo.tmp && mv Cargo.tmp Cargo.toml
           # Protos commit hash
-          toml set Cargo.toml workspace.dependencies.aptos-protos.rev "$aptos_protos_commit_hash" > Cargo.tmp && mv Cargo.tmp Cargo.toml 
-          toml set Cargo.toml workspace.dependencies.aptos-indexer-test-transactions.rev "$aptos_protos_commit_hash" > Cargo.tmp && mv Cargo.tmp Cargo.toml
+          toml set Cargo.toml workspace.dependencies.aptos-protos.rev "$APTOS_PROTOS_COMMIT_HASH" > Cargo.tmp && mv Cargo.tmp Cargo.toml
+          toml set Cargo.toml workspace.dependencies.aptos-indexer-test-transactions.rev "$APTOS_PROTOS_COMMIT_HASH" > Cargo.tmp && mv Cargo.tmp Cargo.toml
           cargo build || true
         working-directory: .
       - name: Configure Git user
@@ -69,28 +69,30 @@ jobs:
           git config --global user.name "Aptos Bot"
           git config --global user.email "aptos-bot@aptoslabs.com"
       - name: Commit and Push Changes
+        env:
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.token }}
+          BRANCH_NAME: ${{ github.event.inputs.branch_name || github.event.client_payload.branch_name }}
+          COMMIT_HASH: ${{ github.event.inputs.commit_hash || github.event.client_payload.commit_hash }}
         run: |
            set -e
-           branch_name="${{ github.event.inputs.branch_name || github.event.client_payload.branch_name }}-update-sdk"
-           commit_hash="${{ github.event.inputs.commit_hash || github.event.client_payload.commit_hash }}"
+           branch_name="${BRANCH_NAME}-update-sdk"
            git checkout -b "$branch_name"
            git add Cargo.toml
            git add Cargo.lock
-           git commit -m "Update sdk to $commit_hash"
+           git commit -m "Update sdk to $COMMIT_HASH"
            git push origin "$branch_name" --force
-        env:
-          GITHUB_TOKEN: ${{ steps.secrets.outputs.token }}
         working-directory: .
       - name: Create Pull Request
+        env:
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.token }}
+          BRANCH_NAME: ${{ github.event.inputs.branch_name || github.event.client_payload.branch_name }}
         run: |
-          branch_name="${{ github.event.inputs.branch_name || github.event.client_payload.branch_name }}-update-sdk"
-          gh pr create --title "Update sdk to upstream branch ${{ github.event.inputs.branch_name || github.event.client_payload.branch_name }}" \
+          branch_name="${BRANCH_NAME}-update-sdk"
+          gh pr create --title "Update sdk to upstream branch $BRANCH_NAME" \
                        --body "This PR updates sdk to new version." \
                        --base main \
                        --head "$branch_name" \
                        --label "indexer-sdk-update"
-        env:
-          GITHUB_TOKEN: ${{ steps.secrets.outputs.token }}
       - name: Run Integration Tests
         run: cargo test --manifest-path integration-tests/Cargo.toml
         working-directory: .


### PR DESCRIPTION
## Summary
Security hardening of GitHub Actions workflows based on a zizmor audit of the aptos-labs org.

> Note: `template-injection` and `dangerous-triggers` fixes are in a separate open PR (`fix/ci-template-injection`).

## Changes
| Rule | Findings | Fix applied |
|---|---|---|
| `unpinned-uses` | 22 (error) | Pinned all mutable action refs to commit SHAs |
| `excessive-permissions` | 10 (7 warning, 3 error) | Added scoped `permissions:` blocks per-job |
| `artipacked` | 10 (warning) | Added `persist-credentials: false` to all checkout steps |
| `cache-poisoning` | 1 (error) | Pinned `actions/setup-node` to SHA (resolves setup-node cache vector) |

**Total addressed: 41 findings** (excluding `template-injection` and `dangerous-triggers` which are handled in the parallel PR)

## Tag immutability verification
All flagged action repos were checked via the GitHub Rulesets API (`repos/{owner}/{repo}/rulesets`). None had active `deletion` or `non_fast_forward` tag-protection rules, so all mutable tags were replaced with commit SHAs:

| Action | Tag | Pinned SHA |
|---|---|---|
| `actions/checkout` | `v4` | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `actions/cache` | `v4` | `0057852bfaa89a56745cba8c7296529d2fc39830` |
| `actions/upload-artifact` | `v4` | `ea165f8d65b6e75b540449e92b4886f43607fa02` |
| `actions/download-artifact` | `v4` | `d3f86a106a0bac45b974a628896c90dbdf5c8093` |
| `actions/setup-node` | `v4` | `49933ea5288caeca8642d1e84afbd3f7d6820020` |
| `dsherret/rust-toolchain-file` | `v1` | `3551321aa44dd44a0393eb3b6bdfbc5d25ecf621` |
| `slackapi/slack-github-action` | `v1.24.0` | `e28cf165c92ffef168d23c5c9000cffc8a25e117` |
| `codecov/codecov-action` | `v5` | `75cd11691c0faa626561e295848008c8a7dddffe` |
| `google-github-actions/auth` | `v2` | `c200f3691d83b41bf9bbd8638997a462592937ed` |
| `google-github-actions/get-secretmanager-secrets` | `v2` | `2b5f97c5a4b9c105e64646762ad4fc3f5128e6f5` |
| `actions-rust-lang/setup-rust-toolchain` | `v1` | `46268bd060767258de96ed93c1251119784f2ab6` |
| `aptos-labs/aptos-core/.github/actions/docker-setup` | `main` | `14efd0101914b720aae3b47a9a2635b862f42fc4` |

## Test plan
- [ ] All YAML files parse without errors (`python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.y*ml')]"`)
- [ ] CI passes on this branch
- [ ] No remaining zizmor findings at error severity (excluding template-injection/dangerous-triggers)