### PR TITLE
[GEO-455] Use IF NOT EXISTS for function_info column migration on signatures table

### DIFF
--- a/processor/src/db/migrations/2025-11-03-230903_add_signature_function_info/down.sql
+++ b/processor/src/db/migrations/2025-11-03-230903_add_signature_function_info/down.sql
@@ -1,3 +1,3 @@
 -- This file should undo anything in `up.sql`
 ALTER TABLE signatures
-DROP COLUMN function_info;
+DROP COLUMN IF EXISTS function_info;

--- a/processor/src/db/migrations/2025-11-03-230903_add_signature_function_info/up.sql
+++ b/processor/src/db/migrations/2025-11-03-230903_add_signature_function_info/up.sql
@@ -1,3 +1,3 @@
 -- Your SQL goes here
 ALTER TABLE signatures
-ADD COLUMN function_info VARCHAR(1000);
+ADD COLUMN IF NOT EXISTS function_info VARCHAR(1000);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fix the `2025-11-03-230903_add_signature_function_info` migration to use `IF NOT EXISTS` / `IF EXISTS` guards, preventing a panic when the `function_info` column already exists on the `signatures` table.

This was reported by OKX: after upgrading to Indexer v2.4.1, their indexer panicked with:
```
DatabaseError(Unknown, "column \"function_info\" of relation \"signatures\" already exists")
```

The root cause is that the migration uses bare `ADD COLUMN function_info` without `IF NOT EXISTS`. The neighboring migration `2025-02-19-200149_signatures_parsing` correctly uses `IF NOT EXISTS` for its column additions. This fix makes the `function_info` migration consistent with that pattern.

The column can already exist due to:
- A partially-applied migration (crash/disconnect between DDL commit and diesel tracking record)
- Race condition when multiple processor instances run migrations simultaneously on startup
- Manual schema changes by operators

## Test Plan
The change is a safe SQL modification: `ADD COLUMN` → `ADD COLUMN IF NOT EXISTS` (and `DROP COLUMN` → `DROP COLUMN IF EXISTS` in down.sql). If the column doesn't exist, behavior is identical. If it does exist, the migration becomes a no-op instead of panicking.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://aptos-org.slack.com/archives/C03MN5F7WUV/p1779073238157089?thread_ts=1779073238.157089&cid=C03MN5F7WUV)

<div><a href="https://cursor.com/agents/bc-98117b9a-7633-500e-97df-c50afd1aec08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98117b9a-7633-500e-97df-c50afd1aec08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

