### PR TITLE
Add alerting processor with prometheus sink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,12 @@ build
 node_modules/
 lcov.info
 
+# Claude Code local state
+.claude/
+
+# Local processor configs (may contain auth tokens; example-*.yaml are committed)
+processor/local-*.yaml
+
 # Rust specific ignores
 # Please follow https://help.github.com/en/articles/ignoring-files to create a global
 # .gitignore file locally for IDE/Emacs/Vim generated files.

--- a/processor/example-config-alerting.yaml
+++ b/processor/example-config-alerting.yaml
@@ -1,0 +1,95 @@
+health_check_port: 8085
+server_config:
+  alerting_config:
+    # ---- Chain binding ------------------------------------------------------
+    # Required. The processor fetches the chain ID from the gRPC stream at
+    # startup and bails on mismatch — guards against pointing testnet creds
+    # at a mainnet config (or vice versa). Mainnet=1, testnet=2.
+    chain_id: 1
+
+    # ---- Identity & metric labeling -----------------------------------------
+    # Every alerting metric is labeled with `instance`. Use distinct values
+    # per deployment so PromQL can distinguish live traffic from replay runs,
+    # canary deploys, etc.
+    # Default: "live" (set when omitted).
+    instance_label: live
+
+    # ---- Run shape: live (default) vs replay --------------------------------
+    # `from_version` / `to_version` are both optional. Unset means LIVE mode:
+    # the processor starts at the chain's current tip and runs forever.
+    #
+    # For a bounded REPLAY run (e.g. "what would have fired during the outage
+    # last Tuesday?"), set both. The processor sweeps that range and exits.
+    # Replay runs typically also set `max_alert_age_secs: 0` (below) and a
+    # `sinks:` map that omits paging sinks, so old matches don't page.
+    #
+    # from_version: 123456789
+    # to_version:   123466789
+
+    # ---- Stale-event guard --------------------------------------------------
+    # Drop matches whose block timestamp is older than this many seconds.
+    # Defensive: in live mode the pipeline runs at tip and this rarely fires;
+    # in replay mode set this to 0 so historical matches aren't silently
+    # dropped.
+    # Default: 300.
+    max_alert_age_secs: 60
+
+    # ---- Rules --------------------------------------------------------------
+    # Each rule fires on events matching its (module_address, module_name,
+    # event_name) tuple, optionally narrowed by `conditions` on the payload.
+    # Replace these with the events you actually care about.
+    rules:
+      # Example 1: existence-based alert. No conditions — every event of
+      # this type that arrives increments event_match_total{rule=...}
+      # so you can page on "any occurrence in the last 30m".
+      - name: example_existence_alert
+        module_address: "0xREPLACE_WITH_MODULE_ADDRESS"
+        module_name: replace_with_module_name
+        event_name: ReplaceWithEventName
+        sinks: [prometheus]
+
+      # Example 2: payload-conditioned alert. The `conditions` array is
+      # AND-combined; all must match. Supported ops: eq, ne, gt, gte, lt,
+      # lte. Move u64/u128 values arrive as strings — the processor
+      # compares them numerically.
+      - name: example_conditioned_alert
+        module_address: "0xREPLACE_WITH_MODULE_ADDRESS"
+        module_name: replace_with_module_name
+        event_name: ReplaceWithEventName
+        conditions:
+          - { path: "some_field",          op: gt, value: "1000000000" }
+          - { path: "nested.path.example", op: eq, value: "expected_value" }
+        sinks: [prometheus]
+
+      # Example 3: SUM-over-window aggregate. `emit_field_values` lists
+      # numeric payload fields the processor should accumulate into
+      # event_field_value_total{field=...}. Use Grafana
+      # `sum(increase(...{field="..."}[30m]))` to do the windowing — no
+      # in-process accumulator. Field paths support dot-notation; values
+      # that fail to parse as u128 are counted in
+      # event_field_parse_errors_total.
+      - name: example_aggregate_alert
+        module_address: "0xREPLACE_WITH_MODULE_ADDRESS"
+        module_name: replace_with_module_name
+        event_name: ReplaceWithEventName
+        emit_field_values: [numeric_field_a, numeric_field_b]
+        sinks: [prometheus]
+
+    # ---- Sinks --------------------------------------------------------------
+    # The built-in `prometheus` sink is always registered. Every rule
+    # increments `event_match_total{rule, event_type, instance}` and (if
+    # `emit_field_values:` is set) `event_field_value_total{rule, field,
+    # instance}` — Grafana does the windowed aggregation. Richer sink
+    # kinds (webhooks, etc.) ship in a follow-up PR.
+
+    # ---- Channel size between pipeline stages -------------------------------
+    # Default: 10. Raise if you see backpressure logs from the extractor or
+    # dispatcher under high event rates.
+    # channel_size: 10
+
+  transaction_stream_config:
+    indexer_grpc_data_service_address: "https://grpc.mainnet.aptoslabs.com:443"
+    auth_token: "REPLACE_WITH_YOUR_TOKEN"
+    # Free-form identifier sent as the `x-aptos-request-name` gRPC header.
+    # Used server-side for rate-limit attribution and request logging.
+    request_name_header: "alerting"

--- a/processor/src/alerting/alerting_dispatcher.rs
+++ b/processor/src/alerting/alerting_dispatcher.rs
@@ -2,9 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::{alerting_extractor::MatchedEvent, sinks::AlertSinkHandle};
-use crate::utils::counters::{
-    EVENT_STALE_DROPPED_TOTAL, EVENT_PIPELINE_LAG_SECONDS,
-};
+use crate::utils::counters::{EVENT_PIPELINE_LAG_SECONDS, EVENT_STALE_DROPPED_TOTAL};
 use aptos_indexer_processor_sdk::{
     aptos_indexer_transaction_stream::utils::time::parse_timestamp,
     traits::{AsyncStep, NamedStep, Processable, async_step::AsyncRunType},
@@ -156,12 +154,18 @@ mod tests {
         }
     }
 
-    fn dispatcher_with(sink_name: &str, max_alert_age_secs: u64) -> (AlertDispatcherStep, Arc<CaptureSink>) {
+    fn dispatcher_with(
+        sink_name: &str,
+        max_alert_age_secs: u64,
+    ) -> (AlertDispatcherStep, Arc<CaptureSink>) {
         let sink = Arc::new(CaptureSink {
             delivered: Mutex::new(vec![]),
         });
         let mut sinks: HashMap<String, Arc<dyn AlertSinkHandle>> = HashMap::new();
-        sinks.insert(sink_name.to_string(), sink.clone() as Arc<dyn AlertSinkHandle>);
+        sinks.insert(
+            sink_name.to_string(),
+            sink.clone() as Arc<dyn AlertSinkHandle>,
+        );
         (
             AlertDispatcherStep::new(sinks, max_alert_age_secs, "test".to_string()),
             sink,
@@ -176,7 +180,9 @@ mod tests {
     fn fresh_events_are_delivered_to_named_sink() {
         let (dispatcher, sink) = dispatcher_with("test_sink", 300);
         dispatcher.dispatch(&matched("r1", vec!["test_sink"], 0), now());
-        assert_eq!(sink.delivered.lock().unwrap().as_slice(), &["r1".to_string()]);
+        assert_eq!(sink.delivered.lock().unwrap().as_slice(), &[
+            "r1".to_string()
+        ]);
     }
 
     #[test]
@@ -195,17 +201,15 @@ mod tests {
 
     #[test]
     fn lag_gauge_reflects_now_minus_block_timestamp() {
-        use aptos_indexer_processor_sdk::aptos_protos::util::timestamp::Timestamp;
-        use aptos_indexer_processor_sdk::types::transaction_context::TransactionMetadata;
+        use aptos_indexer_processor_sdk::{
+            aptos_protos::util::timestamp::Timestamp,
+            types::transaction_context::TransactionMetadata,
+        };
 
         // Distinct instance so this test doesn't race against the other tests'
         // gauge values.
         let label = format!("lag_test_{}", Utc::now().timestamp_nanos_opt().unwrap());
-        let dispatcher = AlertDispatcherStep::new(
-            HashMap::new(),
-            0,
-            label.clone(),
-        );
+        let dispatcher = AlertDispatcherStep::new(HashMap::new(), 0, label.clone());
 
         let lag_secs = 42i64;
         let block_ts_secs = Utc::now().timestamp() - lag_secs;
@@ -238,7 +242,10 @@ mod tests {
     fn lag_gauge_skips_when_timestamp_missing() {
         use aptos_indexer_processor_sdk::types::transaction_context::TransactionMetadata;
 
-        let label = format!("lag_test_skip_{}", Utc::now().timestamp_nanos_opt().unwrap());
+        let label = format!(
+            "lag_test_skip_{}",
+            Utc::now().timestamp_nanos_opt().unwrap()
+        );
         let dispatcher = AlertDispatcherStep::new(HashMap::new(), 0, label.clone());
 
         let batch = TransactionContext::<Vec<MatchedEvent>> {

--- a/processor/src/alerting/alerting_dispatcher.rs
+++ b/processor/src/alerting/alerting_dispatcher.rs
@@ -50,7 +50,7 @@ impl AlertDispatcherStep {
                 .inc();
             return;
         }
-        info!(
+        debug!(
             instance = self.instance_label.as_str(),
             rule = event.rule_name.as_str(),
             event_type = event.event_type.as_str(),
@@ -165,9 +165,10 @@ mod tests {
     fn fresh_events_are_delivered_to_named_sink() {
         let (dispatcher, sink) = dispatcher_with("test_sink", 300);
         dispatcher.dispatch(&matched("r1", vec!["test_sink"], 0), now());
-        assert_eq!(sink.delivered.lock().unwrap().as_slice(), &[
-            "r1".to_string()
-        ]);
+        assert_eq!(
+            sink.delivered.lock().unwrap().as_slice(),
+            &["r1".to_string()]
+        );
     }
 
     #[test]

--- a/processor/src/alerting/alerting_dispatcher.rs
+++ b/processor/src/alerting/alerting_dispatcher.rs
@@ -1,0 +1,268 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use super::{alerting_extractor::MatchedEvent, sinks::AlertSinkHandle};
+use crate::utils::counters::{
+    EVENT_STALE_DROPPED_TOTAL, EVENT_PIPELINE_LAG_SECONDS,
+};
+use aptos_indexer_processor_sdk::{
+    aptos_indexer_transaction_stream::utils::time::parse_timestamp,
+    traits::{AsyncStep, NamedStep, Processable, async_step::AsyncRunType},
+    types::transaction_context::TransactionContext,
+    utils::errors::ProcessorError,
+};
+use async_trait::async_trait;
+use chrono::Utc;
+use std::{collections::HashMap, sync::Arc};
+use tracing::{info, warn};
+
+/// Routes matched events to configured sinks. Pass-through: emits the same
+/// `Vec<MatchedEvent>` it received so a test harness or future downstream
+/// step can observe what was dispatched.
+///
+/// **Stale-event guard.** Matches whose block timestamp is older than
+/// `max_alert_age_secs` are dropped (not delivered to any sink) to prevent
+/// firing stale pages during transient lag spikes. Defensive — in live
+/// mode lag should be near zero; in replay mode operators typically set
+/// `max_alert_age_secs: 0` to disable this guard.
+///
+/// **Pipeline lag.** Each batch updates
+/// `event_pipeline_lag_seconds{instance}` from the batch's most
+/// recent block timestamp. First-class paging signal — a separate Grafana
+/// rule pages when lag exceeds threshold.
+pub struct AlertDispatcherStep {
+    sinks: HashMap<String, Arc<dyn AlertSinkHandle>>,
+    max_alert_age_secs: u64,
+    instance_label: String,
+}
+
+impl AlertDispatcherStep {
+    pub fn new(
+        sinks: HashMap<String, Arc<dyn AlertSinkHandle>>,
+        max_alert_age_secs: u64,
+        instance_label: String,
+    ) -> Self {
+        Self {
+            sinks,
+            max_alert_age_secs,
+            instance_label,
+        }
+    }
+
+    fn is_stale(&self, event_timestamp_secs: i64, now_secs: i64) -> bool {
+        // max_alert_age_secs == 0 means "no stale check"
+        if self.max_alert_age_secs == 0 {
+            return false;
+        }
+        now_secs.saturating_sub(event_timestamp_secs) > self.max_alert_age_secs as i64
+    }
+
+    fn dispatch(&self, event: &MatchedEvent, now_secs: i64) {
+        if self.is_stale(event.timestamp_secs, now_secs) {
+            EVENT_STALE_DROPPED_TOTAL
+                .with_label_values(&[&event.rule_name, &self.instance_label])
+                .inc();
+            return;
+        }
+        info!(
+            instance = self.instance_label.as_str(),
+            rule = event.rule_name.as_str(),
+            event_type = event.event_type.as_str(),
+            version = event.version,
+            sinks = ?event.sinks,
+            "Rule matched event; dispatching to sinks"
+        );
+        for sink_name in &event.sinks {
+            match self.sinks.get(sink_name) {
+                Some(handle) => handle.try_deliver(event),
+                None => warn!(
+                    rule = event.rule_name.as_str(),
+                    sink = sink_name.as_str(),
+                    "Rule references unknown sink — delivery skipped",
+                ),
+            }
+        }
+    }
+
+    fn update_lag_gauge<T>(&self, batch: &TransactionContext<T>, now_secs: i64) {
+        let Some(ts) = batch.metadata.end_transaction_timestamp.as_ref() else {
+            return;
+        };
+        let block_ts_secs = parse_timestamp(ts, batch.metadata.end_version as i64).timestamp();
+        let lag = now_secs.saturating_sub(block_ts_secs);
+        EVENT_PIPELINE_LAG_SECONDS
+            .with_label_values(&[&self.instance_label])
+            .set(lag);
+    }
+}
+
+#[async_trait]
+impl Processable for AlertDispatcherStep {
+    type Input = Vec<MatchedEvent>;
+    type Output = Vec<MatchedEvent>;
+    type RunType = AsyncRunType;
+
+    async fn process(
+        &mut self,
+        batch: TransactionContext<Self::Input>,
+    ) -> Result<Option<TransactionContext<Self::Output>>, ProcessorError> {
+        // Single time read shared across the lag gauge update and every
+        // per-event staleness check in this batch — saves N-1 syscalls
+        // when a batch carries many matches.
+        let now_secs = Utc::now().timestamp();
+        self.update_lag_gauge(&batch, now_secs);
+        for matched in &batch.data {
+            self.dispatch(matched, now_secs);
+        }
+        Ok(Some(batch))
+    }
+}
+
+impl AsyncStep for AlertDispatcherStep {}
+
+impl NamedStep for AlertDispatcherStep {
+    fn name(&self) -> String {
+        "AlertDispatcherStep".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct CaptureSink {
+        delivered: Mutex<Vec<String>>,
+    }
+
+    impl AlertSinkHandle for CaptureSink {
+        fn try_deliver(&self, event: &MatchedEvent) {
+            self.delivered.lock().unwrap().push(event.rule_name.clone());
+        }
+    }
+
+    fn matched(rule: &str, sinks: Vec<&str>, age_secs: i64) -> MatchedEvent {
+        let now = Utc::now().timestamp();
+        MatchedEvent {
+            rule_name: rule.to_string(),
+            event_type: "0x1::coin::WithdrawEvent".to_string(),
+            version: 1,
+            timestamp_secs: now - age_secs,
+            payload: Arc::new(json!({})),
+            field_values: vec![],
+            sinks: sinks.into_iter().map(String::from).collect(),
+        }
+    }
+
+    fn dispatcher_with(sink_name: &str, max_alert_age_secs: u64) -> (AlertDispatcherStep, Arc<CaptureSink>) {
+        let sink = Arc::new(CaptureSink {
+            delivered: Mutex::new(vec![]),
+        });
+        let mut sinks: HashMap<String, Arc<dyn AlertSinkHandle>> = HashMap::new();
+        sinks.insert(sink_name.to_string(), sink.clone() as Arc<dyn AlertSinkHandle>);
+        (
+            AlertDispatcherStep::new(sinks, max_alert_age_secs, "test".to_string()),
+            sink,
+        )
+    }
+
+    fn now() -> i64 {
+        Utc::now().timestamp()
+    }
+
+    #[test]
+    fn fresh_events_are_delivered_to_named_sink() {
+        let (dispatcher, sink) = dispatcher_with("test_sink", 300);
+        dispatcher.dispatch(&matched("r1", vec!["test_sink"], 0), now());
+        assert_eq!(sink.delivered.lock().unwrap().as_slice(), &["r1".to_string()]);
+    }
+
+    #[test]
+    fn stale_events_are_dropped() {
+        let (dispatcher, sink) = dispatcher_with("test_sink", 60);
+        dispatcher.dispatch(&matched("r1", vec!["test_sink"], 120), now());
+        assert!(sink.delivered.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn zero_max_age_disables_stale_check() {
+        let (dispatcher, sink) = dispatcher_with("test_sink", 0);
+        dispatcher.dispatch(&matched("r1", vec!["test_sink"], 1_000_000), now());
+        assert_eq!(sink.delivered.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn lag_gauge_reflects_now_minus_block_timestamp() {
+        use aptos_indexer_processor_sdk::aptos_protos::util::timestamp::Timestamp;
+        use aptos_indexer_processor_sdk::types::transaction_context::TransactionMetadata;
+
+        // Distinct instance so this test doesn't race against the other tests'
+        // gauge values.
+        let label = format!("lag_test_{}", Utc::now().timestamp_nanos_opt().unwrap());
+        let dispatcher = AlertDispatcherStep::new(
+            HashMap::new(),
+            0,
+            label.clone(),
+        );
+
+        let lag_secs = 42i64;
+        let block_ts_secs = Utc::now().timestamp() - lag_secs;
+        let batch = TransactionContext::<Vec<MatchedEvent>> {
+            data: vec![],
+            metadata: TransactionMetadata {
+                end_version: 100,
+                end_transaction_timestamp: Some(Timestamp {
+                    seconds: block_ts_secs,
+                    nanos: 0,
+                }),
+                ..Default::default()
+            },
+        };
+
+        dispatcher.update_lag_gauge(&batch, Utc::now().timestamp());
+
+        let observed = EVENT_PIPELINE_LAG_SECONDS
+            .with_label_values(&[&label])
+            .get();
+        // 2-second slack for the time elapsed between computing block_ts_secs
+        // and reading the gauge.
+        assert!(
+            (lag_secs - observed).abs() <= 2,
+            "expected lag near {lag_secs}, got {observed}"
+        );
+    }
+
+    #[test]
+    fn lag_gauge_skips_when_timestamp_missing() {
+        use aptos_indexer_processor_sdk::types::transaction_context::TransactionMetadata;
+
+        let label = format!("lag_test_skip_{}", Utc::now().timestamp_nanos_opt().unwrap());
+        let dispatcher = AlertDispatcherStep::new(HashMap::new(), 0, label.clone());
+
+        let batch = TransactionContext::<Vec<MatchedEvent>> {
+            data: vec![],
+            metadata: TransactionMetadata {
+                end_version: 100,
+                end_transaction_timestamp: None,
+                ..Default::default()
+            },
+        };
+
+        dispatcher.update_lag_gauge(&batch, Utc::now().timestamp());
+
+        // Gauge was never set; default IntGauge value is 0.
+        let observed = EVENT_PIPELINE_LAG_SECONDS
+            .with_label_values(&[&label])
+            .get();
+        assert_eq!(observed, 0);
+    }
+
+    #[test]
+    fn unknown_sink_is_skipped_silently() {
+        let (dispatcher, sink) = dispatcher_with("test_sink", 300);
+        dispatcher.dispatch(&matched("r1", vec!["nonexistent"], 0), now());
+        assert!(sink.delivered.lock().unwrap().is_empty());
+    }
+}

--- a/processor/src/alerting/alerting_dispatcher.rs
+++ b/processor/src/alerting/alerting_dispatcher.rs
@@ -6,7 +6,7 @@ use crate::utils::counters::{EVENT_PIPELINE_LAG_SECONDS, EVENT_STALE_DROPPED_TOT
 use aptos_indexer_processor_sdk::{
     aptos_indexer_transaction_stream::utils::time::parse_timestamp,
     traits::{AsyncStep, NamedStep, Processable, async_step::AsyncRunType},
-    types::transaction_context::TransactionContext,
+    types::transaction_context::{TransactionContext, TransactionMetadata},
     utils::errors::ProcessorError,
 };
 use async_trait::async_trait;
@@ -14,20 +14,9 @@ use chrono::Utc;
 use std::{collections::HashMap, sync::Arc};
 use tracing::{info, warn};
 
-/// Routes matched events to configured sinks. Pass-through: emits the same
-/// `Vec<MatchedEvent>` it received so a test harness or future downstream
-/// step can observe what was dispatched.
-///
-/// **Stale-event guard.** Matches whose block timestamp is older than
-/// `max_alert_age_secs` are dropped (not delivered to any sink) to prevent
-/// firing stale pages during transient lag spikes. Defensive — in live
-/// mode lag should be near zero; in replay mode operators typically set
-/// `max_alert_age_secs: 0` to disable this guard.
-///
-/// **Pipeline lag.** Each batch updates
-/// `event_pipeline_lag_seconds{instance}` from the batch's most
-/// recent block timestamp. First-class paging signal — a separate Grafana
-/// rule pages when lag exceeds threshold.
+/// Routes matched events to configured sinks. Drops matches older than
+/// `max_alert_age_secs` (set to 0 in replay mode to disable). Each batch
+/// updates `event_pipeline_lag_seconds{instance}`.
 pub struct AlertDispatcherStep {
     sinks: HashMap<String, Arc<dyn AlertSinkHandle>>,
     max_alert_age_secs: u64,
@@ -48,7 +37,6 @@ impl AlertDispatcherStep {
     }
 
     fn is_stale(&self, event_timestamp_secs: i64, now_secs: i64) -> bool {
-        // max_alert_age_secs == 0 means "no stale check"
         if self.max_alert_age_secs == 0 {
             return false;
         }
@@ -82,11 +70,11 @@ impl AlertDispatcherStep {
         }
     }
 
-    fn update_lag_gauge<T>(&self, batch: &TransactionContext<T>, now_secs: i64) {
-        let Some(ts) = batch.metadata.end_transaction_timestamp.as_ref() else {
+    fn update_lag_gauge(&self, metadata: &TransactionMetadata, now_secs: i64) {
+        let Some(ts) = metadata.end_transaction_timestamp.as_ref() else {
             return;
         };
-        let block_ts_secs = parse_timestamp(ts, batch.metadata.end_version as i64).timestamp();
+        let block_ts_secs = parse_timestamp(ts, metadata.end_version as i64).timestamp();
         let lag = now_secs.saturating_sub(block_ts_secs);
         EVENT_PIPELINE_LAG_SECONDS
             .with_label_values(&[&self.instance_label])
@@ -104,11 +92,8 @@ impl Processable for AlertDispatcherStep {
         &mut self,
         batch: TransactionContext<Self::Input>,
     ) -> Result<Option<TransactionContext<Self::Output>>, ProcessorError> {
-        // Single time read shared across the lag gauge update and every
-        // per-event staleness check in this batch — saves N-1 syscalls
-        // when a batch carries many matches.
         let now_secs = Utc::now().timestamp();
-        self.update_lag_gauge(&batch, now_secs);
+        self.update_lag_gauge(&batch.metadata, now_secs);
         for matched in &batch.data {
             self.dispatch(matched, now_secs);
         }
@@ -201,69 +186,26 @@ mod tests {
 
     #[test]
     fn lag_gauge_reflects_now_minus_block_timestamp() {
-        use aptos_indexer_processor_sdk::{
-            aptos_protos::util::timestamp::Timestamp,
-            types::transaction_context::TransactionMetadata,
-        };
+        use aptos_indexer_processor_sdk::aptos_protos::util::timestamp::Timestamp;
 
-        // Distinct instance so this test doesn't race against the other tests'
-        // gauge values.
         let label = format!("lag_test_{}", Utc::now().timestamp_nanos_opt().unwrap());
         let dispatcher = AlertDispatcherStep::new(HashMap::new(), 0, label.clone());
-
         let lag_secs = 42i64;
-        let block_ts_secs = Utc::now().timestamp() - lag_secs;
-        let batch = TransactionContext::<Vec<MatchedEvent>> {
-            data: vec![],
-            metadata: TransactionMetadata {
-                end_version: 100,
-                end_transaction_timestamp: Some(Timestamp {
-                    seconds: block_ts_secs,
-                    nanos: 0,
-                }),
-                ..Default::default()
-            },
+        let metadata = TransactionMetadata {
+            end_version: 100,
+            end_transaction_timestamp: Some(Timestamp {
+                seconds: Utc::now().timestamp() - lag_secs,
+                nanos: 0,
+            }),
+            ..Default::default()
         };
 
-        dispatcher.update_lag_gauge(&batch, Utc::now().timestamp());
+        dispatcher.update_lag_gauge(&metadata, Utc::now().timestamp());
 
         let observed = EVENT_PIPELINE_LAG_SECONDS
             .with_label_values(&[&label])
             .get();
-        // 2-second slack for the time elapsed between computing block_ts_secs
-        // and reading the gauge.
-        assert!(
-            (lag_secs - observed).abs() <= 2,
-            "expected lag near {lag_secs}, got {observed}"
-        );
-    }
-
-    #[test]
-    fn lag_gauge_skips_when_timestamp_missing() {
-        use aptos_indexer_processor_sdk::types::transaction_context::TransactionMetadata;
-
-        let label = format!(
-            "lag_test_skip_{}",
-            Utc::now().timestamp_nanos_opt().unwrap()
-        );
-        let dispatcher = AlertDispatcherStep::new(HashMap::new(), 0, label.clone());
-
-        let batch = TransactionContext::<Vec<MatchedEvent>> {
-            data: vec![],
-            metadata: TransactionMetadata {
-                end_version: 100,
-                end_transaction_timestamp: None,
-                ..Default::default()
-            },
-        };
-
-        dispatcher.update_lag_gauge(&batch, Utc::now().timestamp());
-
-        // Gauge was never set; default IntGauge value is 0.
-        let observed = EVENT_PIPELINE_LAG_SECONDS
-            .with_label_values(&[&label])
-            .get();
-        assert_eq!(observed, 0);
+        assert!((lag_secs - observed).abs() <= 2);
     }
 
     #[test]

--- a/processor/src/alerting/alerting_extractor.rs
+++ b/processor/src/alerting/alerting_extractor.rs
@@ -18,46 +18,28 @@ use aptos_indexer_processor_sdk::{
 use async_trait::async_trait;
 use serde_json::Value;
 use std::sync::Arc;
-use tracing::trace;
 
-/// A single rule firing on a single on-chain event. One transaction can
-/// produce many `MatchedEvent`s if multiple rules match or multiple events
-/// match different rules.
-///
-/// Payload is `Arc<Value>` so when N rules match the same event we share
-/// the parsed JSON instead of deep-cloning it N times.
+/// A single rule firing on a single on-chain event. Payload is `Arc<Value>`
+/// so N rules matching the same event share one parsed JSON.
 #[derive(Clone, Debug)]
 pub struct MatchedEvent {
     pub rule_name: String,
     pub event_type: String,
     pub version: u64,
-    /// Block timestamp in unix seconds. Used by the dispatcher's stale-event
-    /// guard and emitted in webhook payloads.
     pub timestamp_secs: i64,
-    /// Decoded event payload. `Null` if `event.data` was empty or unparseable.
     pub payload: Arc<Value>,
-    /// Pre-extracted numeric payload values declared in
-    /// `AlertRule::emit_field_values`. Pairs of `(field_path, value)`.
     pub field_values: Vec<(String, u128)>,
-    /// Names of sinks to deliver this match to (copy of the firing rule's
-    /// `sinks` list, so the dispatcher does not need to look up the rule).
     pub sinks: Vec<String>,
 }
 
-/// Walks transactions, tests each event against every rule, and produces
-/// `MatchedEvent`s with per-rule attribution. Server-side filtering already
-/// narrows the gRPC stream to candidate transactions — this step still does
-/// the finer match because one transaction can carry events of multiple
-/// types and we need to know *which* rule fired.
 pub struct AlertingExtractorStep {
     rules: Vec<AlertRule>,
     instance_label: String,
 }
 
 impl AlertingExtractorStep {
-    /// Assumes `rules` are already canonicalized (module addresses
-    /// standardized). The caller does this once so the server-side filter
-    /// compiler and this client-side matcher see the same addresses.
+    /// Assumes `rules` are already canonicalized — same form the server-side
+    /// filter compiler sees, or the two will disagree about which events match.
     pub fn new(rules: Vec<AlertRule>, instance_label: String) -> Self {
         Self {
             rules,
@@ -67,10 +49,6 @@ impl AlertingExtractorStep {
 
     fn evaluate(&self, event: &Event, version: u64, timestamp_secs: i64) -> Vec<MatchedEvent> {
         let mut matches = Vec::new();
-
-        // Parse payload at most once per event, only if at least one rule's
-        // type filter matches. Stored as `Arc<Value>` so subsequent matches
-        // for the same event share the parsed JSON.
         let mut parsed_payload: Option<Arc<Value>> = None;
 
         for rule in &self.rules {
@@ -78,8 +56,6 @@ impl AlertingExtractorStep {
                 continue;
             }
 
-            // Empty data is valid (some events carry no payload). Treat it as
-            // `Null` so conditions evaluate against a missing path.
             let payload = parsed_payload.get_or_insert_with(|| {
                 let value = if event.data.is_empty() {
                     Value::Null
@@ -89,10 +65,8 @@ impl AlertingExtractorStep {
                 Arc::new(value)
             });
 
-            // Pass = match; Fail = clean miss; ComparisonNonNumeric = event
-            // payload didn't fit the rule's numeric assumption (the worst
-            // case operationally — a rule that "never fires" by mistake),
-            // so surface it on a dedicated counter and skip the rule.
+            // ComparisonNonNumeric on a counter so a rule that silently never
+            // fires is visible — the worst alerting failure mode.
             let mut all_pass = true;
             for c in &rule.conditions {
                 match condition_matches(c, payload.as_ref()) {
@@ -154,19 +128,11 @@ impl Processable for AlertingExtractorStep {
         let mut out: Vec<MatchedEvent> = Vec::new();
 
         for txn in &batch.data {
-            // Server-side filter requests `success=true`; re-check defensively.
-            let is_success = txn.info.as_ref().is_some_and(|info| info.success);
-            if !is_success {
-                continue;
-            }
-
             let Some(timestamp) = txn.timestamp else {
                 continue;
             };
-            let timestamp_secs = timestamp.seconds;
-
             for event in events_of(txn) {
-                out.extend(self.evaluate(event, txn.version, timestamp_secs));
+                out.extend(self.evaluate(event, txn.version, timestamp.seconds));
             }
         }
 
@@ -177,30 +143,13 @@ impl Processable for AlertingExtractorStep {
     }
 }
 
-/// Return the events emitted by a transaction, regardless of which
-/// `TxnData` variant carries them. Genesis/User/BlockMetadata/Validator
-/// txns all expose `events`; other variants (state checkpoints etc.)
-/// have none.
-///
-/// A `tracing::trace!` fires on unhandled `Some(_)` variants so a future
-/// protobuf revision that introduces a new event-bearing variant doesn't
-/// silently degrade the matcher — operators running with
-/// `RUST_LOG=processor::alerting=trace` will see it immediately.
 fn events_of(txn: &Transaction) -> &[Event] {
     match txn.txn_data.as_ref() {
         Some(TxnData::User(inner)) => &inner.events,
         Some(TxnData::BlockMetadata(inner)) => &inner.events,
         Some(TxnData::Genesis(inner)) => &inner.events,
         Some(TxnData::Validator(inner)) => &inner.events,
-        Some(other) => {
-            trace!(
-                txn_data_variant = ?std::mem::discriminant(other),
-                version = txn.version,
-                "Unhandled TxnData variant; alerting matcher sees no events from this txn"
-            );
-            &[]
-        },
-        None => &[],
+        _ => &[],
     }
 }
 
@@ -219,8 +168,6 @@ mod tests {
     use aptos_indexer_processor_sdk::aptos_protos::transaction::v1::Event;
 
     fn test_step(rules: Vec<AlertRule>) -> AlertingExtractorStep {
-        // Mirror what AlertingProcessor::run_processor does in production:
-        // canonicalize module addresses before handing rules to the step.
         let rules = rules
             .into_iter()
             .map(|mut r| {

--- a/processor/src/alerting/alerting_extractor.rs
+++ b/processor/src/alerting/alerting_extractor.rs
@@ -88,17 +88,19 @@ impl AlertingExtractorStep {
                 continue;
             }
 
-            let mut field_values = Vec::with_capacity(rule.emit_field_values.len());
-            for field in &rule.emit_field_values {
-                match read_u128_field(payload.as_ref(), field) {
-                    Some(v) => field_values.push((field.clone(), v)),
+            let field_values: Vec<(String, u128)> = rule
+                .emit_field_values
+                .iter()
+                .filter_map(|field| match read_u128_field(payload.as_ref(), field) {
+                    Some(v) => Some((field.clone(), v)),
                     None => {
                         EVENT_FIELD_PARSE_ERRORS_TOTAL
                             .with_label_values(&[&rule.name, field, &self.instance_label])
                             .inc();
+                        None
                     },
-                }
-            }
+                })
+                .collect();
 
             matches.push(MatchedEvent {
                 rule_name: rule.name.clone(),

--- a/processor/src/alerting/alerting_extractor.rs
+++ b/processor/src/alerting/alerting_extractor.rs
@@ -224,10 +224,9 @@ mod tests {
         let rules = rules
             .into_iter()
             .map(|mut r| {
-                r.module_address =
-                    aptos_indexer_processor_sdk::utils::convert::standardize_address(
-                        &r.module_address,
-                    );
+                r.module_address = aptos_indexer_processor_sdk::utils::convert::standardize_address(
+                    &r.module_address,
+                );
                 r
             })
             .collect();
@@ -267,7 +266,10 @@ mod tests {
                 op: CondOp::Gt,
                 value: serde_json::json!("99999999"),
             }],
-            vec!["withdraw_amount".to_string(), "asset_from_paired".to_string()],
+            vec![
+                "withdraw_amount".to_string(),
+                "asset_from_paired".to_string(),
+            ],
         )]);
 
         let evt = event(serde_json::json!({
@@ -284,13 +286,10 @@ mod tests {
         assert_eq!(m.rule_name, "large_withdrawals");
         assert_eq!(m.version, 42);
         assert_eq!(m.timestamp_secs, 1_700_000_000);
-        assert_eq!(
-            m.field_values,
-            vec![
-                ("withdraw_amount".to_string(), 100_000_000),
-                ("asset_from_paired".to_string(), 100_000_000),
-            ]
-        );
+        assert_eq!(m.field_values, vec![
+            ("withdraw_amount".to_string(), 100_000_000),
+            ("asset_from_paired".to_string(), 100_000_000),
+        ]);
     }
 
     #[test]

--- a/processor/src/alerting/alerting_extractor.rs
+++ b/processor/src/alerting/alerting_extractor.rs
@@ -1,0 +1,342 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use super::{
+    config::AlertRule,
+    event_match::{ConditionEval, condition_matches, read_u128_field},
+};
+use crate::{
+    processors::event_file::event_file_extractor::event_matches_filter,
+    utils::counters::{EVENT_CONDITION_COMPARE_ERRORS_TOTAL, EVENT_FIELD_PARSE_ERRORS_TOTAL},
+};
+use aptos_indexer_processor_sdk::{
+    aptos_protos::transaction::v1::{Event, Transaction, transaction::TxnData},
+    traits::{AsyncStep, NamedStep, Processable, async_step::AsyncRunType},
+    types::transaction_context::TransactionContext,
+    utils::errors::ProcessorError,
+};
+use async_trait::async_trait;
+use serde_json::Value;
+use std::sync::Arc;
+use tracing::trace;
+
+/// A single rule firing on a single on-chain event. One transaction can
+/// produce many `MatchedEvent`s if multiple rules match or multiple events
+/// match different rules.
+///
+/// Payload is `Arc<Value>` so when N rules match the same event we share
+/// the parsed JSON instead of deep-cloning it N times.
+#[derive(Clone, Debug)]
+pub struct MatchedEvent {
+    pub rule_name: String,
+    pub event_type: String,
+    pub version: u64,
+    /// Block timestamp in unix seconds. Used by the dispatcher's stale-event
+    /// guard and emitted in webhook payloads.
+    pub timestamp_secs: i64,
+    /// Decoded event payload. `Null` if `event.data` was empty or unparseable.
+    pub payload: Arc<Value>,
+    /// Pre-extracted numeric payload values declared in
+    /// `AlertRule::emit_field_values`. Pairs of `(field_path, value)`.
+    pub field_values: Vec<(String, u128)>,
+    /// Names of sinks to deliver this match to (copy of the firing rule's
+    /// `sinks` list, so the dispatcher does not need to look up the rule).
+    pub sinks: Vec<String>,
+}
+
+/// Walks transactions, tests each event against every rule, and produces
+/// `MatchedEvent`s with per-rule attribution. Server-side filtering already
+/// narrows the gRPC stream to candidate transactions — this step still does
+/// the finer match because one transaction can carry events of multiple
+/// types and we need to know *which* rule fired.
+pub struct AlertingExtractorStep {
+    rules: Vec<AlertRule>,
+    instance_label: String,
+}
+
+impl AlertingExtractorStep {
+    /// Assumes `rules` are already canonicalized (module addresses
+    /// standardized). The caller does this once so the server-side filter
+    /// compiler and this client-side matcher see the same addresses.
+    pub fn new(rules: Vec<AlertRule>, instance_label: String) -> Self {
+        Self {
+            rules,
+            instance_label,
+        }
+    }
+
+    fn evaluate(&self, event: &Event, version: u64, timestamp_secs: i64) -> Vec<MatchedEvent> {
+        let mut matches = Vec::new();
+
+        // Parse payload at most once per event, only if at least one rule's
+        // type filter matches. Stored as `Arc<Value>` so subsequent matches
+        // for the same event share the parsed JSON.
+        let mut parsed_payload: Option<Arc<Value>> = None;
+
+        for rule in &self.rules {
+            if !event_matches_filter(event, &rule.to_event_filter()) {
+                continue;
+            }
+
+            // Empty data is valid (some events carry no payload). Treat it as
+            // `Null` so conditions evaluate against a missing path.
+            let payload = parsed_payload.get_or_insert_with(|| {
+                let value = if event.data.is_empty() {
+                    Value::Null
+                } else {
+                    serde_json::from_str(&event.data).unwrap_or(Value::Null)
+                };
+                Arc::new(value)
+            });
+
+            // Pass = match; Fail = clean miss; ComparisonNonNumeric = event
+            // payload didn't fit the rule's numeric assumption (the worst
+            // case operationally — a rule that "never fires" by mistake),
+            // so surface it on a dedicated counter and skip the rule.
+            let mut all_pass = true;
+            for c in &rule.conditions {
+                match condition_matches(c, payload.as_ref()) {
+                    ConditionEval::Pass => {},
+                    ConditionEval::Fail => {
+                        all_pass = false;
+                        break;
+                    },
+                    ConditionEval::ComparisonNonNumeric => {
+                        EVENT_CONDITION_COMPARE_ERRORS_TOTAL
+                            .with_label_values(&[&rule.name, &c.path, &self.instance_label])
+                            .inc();
+                        all_pass = false;
+                        break;
+                    },
+                }
+            }
+            if !all_pass {
+                continue;
+            }
+
+            let mut field_values = Vec::with_capacity(rule.emit_field_values.len());
+            for field in &rule.emit_field_values {
+                match read_u128_field(payload.as_ref(), field) {
+                    Some(v) => field_values.push((field.clone(), v)),
+                    None => {
+                        EVENT_FIELD_PARSE_ERRORS_TOTAL
+                            .with_label_values(&[&rule.name, field, &self.instance_label])
+                            .inc();
+                    },
+                }
+            }
+
+            matches.push(MatchedEvent {
+                rule_name: rule.name.clone(),
+                event_type: event.type_str.clone(),
+                version,
+                timestamp_secs,
+                payload: Arc::clone(payload),
+                field_values,
+                sinks: rule.sinks.clone(),
+            });
+        }
+
+        matches
+    }
+}
+
+#[async_trait]
+impl Processable for AlertingExtractorStep {
+    type Input = Vec<Transaction>;
+    type Output = Vec<MatchedEvent>;
+    type RunType = AsyncRunType;
+
+    async fn process(
+        &mut self,
+        batch: TransactionContext<Self::Input>,
+    ) -> Result<Option<TransactionContext<Self::Output>>, ProcessorError> {
+        let mut out: Vec<MatchedEvent> = Vec::new();
+
+        for txn in &batch.data {
+            // Server-side filter requests `success=true`; re-check defensively.
+            let is_success = txn.info.as_ref().is_some_and(|info| info.success);
+            if !is_success {
+                continue;
+            }
+
+            let Some(timestamp) = txn.timestamp else {
+                continue;
+            };
+            let timestamp_secs = timestamp.seconds;
+
+            for event in events_of(txn) {
+                out.extend(self.evaluate(event, txn.version, timestamp_secs));
+            }
+        }
+
+        Ok(Some(TransactionContext {
+            data: out,
+            metadata: batch.metadata,
+        }))
+    }
+}
+
+/// Return the events emitted by a transaction, regardless of which
+/// `TxnData` variant carries them. Genesis/User/BlockMetadata/Validator
+/// txns all expose `events`; other variants (state checkpoints etc.)
+/// have none.
+///
+/// A `tracing::trace!` fires on unhandled `Some(_)` variants so a future
+/// protobuf revision that introduces a new event-bearing variant doesn't
+/// silently degrade the matcher — operators running with
+/// `RUST_LOG=processor::alerting=trace` will see it immediately.
+fn events_of(txn: &Transaction) -> &[Event] {
+    match txn.txn_data.as_ref() {
+        Some(TxnData::User(inner)) => &inner.events,
+        Some(TxnData::BlockMetadata(inner)) => &inner.events,
+        Some(TxnData::Genesis(inner)) => &inner.events,
+        Some(TxnData::Validator(inner)) => &inner.events,
+        Some(other) => {
+            trace!(
+                txn_data_variant = ?std::mem::discriminant(other),
+                version = txn.version,
+                "Unhandled TxnData variant; alerting matcher sees no events from this txn"
+            );
+            &[]
+        },
+        None => &[],
+    }
+}
+
+impl AsyncStep for AlertingExtractorStep {}
+
+impl NamedStep for AlertingExtractorStep {
+    fn name(&self) -> String {
+        "AlertingExtractorStep".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::alerting::config::{AlertRule, CondOp, EventCondition};
+    use aptos_indexer_processor_sdk::aptos_protos::transaction::v1::Event;
+
+    fn test_step(rules: Vec<AlertRule>) -> AlertingExtractorStep {
+        // Mirror what AlertingProcessor::run_processor does in production:
+        // canonicalize module addresses before handing rules to the step.
+        let rules = rules
+            .into_iter()
+            .map(|mut r| {
+                r.module_address =
+                    aptos_indexer_processor_sdk::utils::convert::standardize_address(
+                        &r.module_address,
+                    );
+                r
+            })
+            .collect();
+        AlertingExtractorStep::new(rules, "test".to_string())
+    }
+
+    const ADDR_64: &str = "0xbae207659db88bea0cbead6da0ed00aac12edcdda169e591cd41c94180b46f3b";
+
+    fn rule(name: &str, conditions: Vec<EventCondition>, emit: Vec<String>) -> AlertRule {
+        AlertRule {
+            name: name.to_string(),
+            module_address: "0x1".to_string(),
+            module_name: Some("coin".to_string()),
+            event_name: Some("WithdrawEvent".to_string()),
+            conditions,
+            emit_field_values: emit,
+            sinks: vec!["prometheus".to_string()],
+        }
+    }
+
+    fn event(payload: serde_json::Value) -> Event {
+        Event {
+            type_str:
+                "0x0000000000000000000000000000000000000000000000000000000000000001::coin::WithdrawEvent"
+                    .to_string(),
+            data: payload.to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn evaluates_users_example_payload_with_gt_condition() {
+        let step = test_step(vec![rule(
+            "large_withdrawals",
+            vec![EventCondition {
+                path: "withdraw_amount".to_string(),
+                op: CondOp::Gt,
+                value: serde_json::json!("99999999"),
+            }],
+            vec!["withdraw_amount".to_string(), "asset_from_paired".to_string()],
+        )]);
+
+        let evt = event(serde_json::json!({
+            "__variant__": "V1",
+            "asset_from_main": "0",
+            "asset_from_paired": "100000000",
+            "asset_type": { "inner": ADDR_64 },
+            "withdraw_amount": "100000000"
+        }));
+
+        let matches = step.evaluate(&evt, 42, 1_700_000_000);
+        assert_eq!(matches.len(), 1);
+        let m = &matches[0];
+        assert_eq!(m.rule_name, "large_withdrawals");
+        assert_eq!(m.version, 42);
+        assert_eq!(m.timestamp_secs, 1_700_000_000);
+        assert_eq!(
+            m.field_values,
+            vec![
+                ("withdraw_amount".to_string(), 100_000_000),
+                ("asset_from_paired".to_string(), 100_000_000),
+            ]
+        );
+    }
+
+    #[test]
+    fn condition_failure_skips_event() {
+        let step = test_step(vec![rule(
+            "huge_only",
+            vec![EventCondition {
+                path: "withdraw_amount".to_string(),
+                op: CondOp::Gt,
+                value: serde_json::json!("1000000000"),
+            }],
+            vec![],
+        )]);
+
+        let evt = event(serde_json::json!({ "withdraw_amount": "100000000" }));
+        assert!(step.evaluate(&evt, 1, 0).is_empty());
+    }
+
+    #[test]
+    fn type_mismatch_skips_event() {
+        let step = test_step(vec![rule("any", vec![], vec![])]);
+        let evt = Event {
+            type_str: "0x1::coin::DepositEvent".to_string(),
+            data: "{}".to_string(),
+            ..Default::default()
+        };
+        assert!(step.evaluate(&evt, 1, 0).is_empty());
+    }
+
+    #[test]
+    fn multiple_rules_can_fire_on_same_event() {
+        let r1 = rule("any_withdrawal", vec![], vec![]);
+        let mut r2 = rule(
+            "v1_only",
+            vec![EventCondition {
+                path: "__variant__".to_string(),
+                op: CondOp::Eq,
+                value: serde_json::json!("V1"),
+            }],
+            vec![],
+        );
+        r2.name = "v1_only".to_string();
+        let step = test_step(vec![r1, r2]);
+
+        let evt = event(serde_json::json!({ "__variant__": "V1", "withdraw_amount": "1" }));
+        let matches = step.evaluate(&evt, 1, 0);
+        assert_eq!(matches.len(), 2);
+    }
+}

--- a/processor/src/alerting/alerting_processor.rs
+++ b/processor/src/alerting/alerting_processor.rs
@@ -16,12 +16,8 @@ use aptos_indexer_processor_sdk::{
 };
 use tracing::{debug, info};
 
-/// Live-first alerting application. Reads the transaction stream and
-/// fans matches out to configured sinks (Prometheus, webhooks). Owns no
-/// durable storage of its own: there is no checkpoint table and no
-/// `VersionTrackerStep` — extended downtime is handled by an
-/// operator-driven replay deploy, not by checkpoint resume (see
-/// `AlertingProcessorConfig::{from_version,to_version,instance_label}`).
+/// Live-first alerting application. No checkpoint table; extended downtime
+/// is handled by an operator-driven replay deploy.
 pub struct AlertingProcessor {
     config: AlertingAppConfig,
 }
@@ -45,9 +41,6 @@ impl ProcessorTrait for AlertingProcessor {
     async fn run_processor(&self) -> Result<()> {
         let alerting = &self.config.alerting_config;
 
-        // Verify the gRPC stream is on the chain this config is bound to.
-        // Catches misconfigured creds / endpoints before any alert metric
-        // gets a single tick under the wrong instance label.
         let actual_chain_id = get_chain_id(self.config.transaction_stream_config.clone()).await?;
         if actual_chain_id != alerting.chain_id {
             bail!(
@@ -57,30 +50,19 @@ impl ProcessorTrait for AlertingProcessor {
             );
         }
 
-        // Live mode: from_version=None -> server-side default (current
-        // tip on the Aptos data service, same path get_chain_id uses).
-        // The pipeline-lag gauge will reveal it immediately if the
-        // server lands far behind tip.
         let starting_version = alerting.from_version;
         let ending_version = alerting.to_version;
 
-        match starting_version {
-            None => info!(
-                instance = alerting.instance_label.as_str(),
-                "Alerting processor starting at chain tip (no from_version set)"
-            ),
-            Some(from) => info!(
-                instance = alerting.instance_label.as_str(),
-                from_version = from,
-                to_version = ending_version,
-                "Alerting processor starting in replay mode"
-            ),
-        }
+        info!(
+            instance = alerting.instance_label.as_str(),
+            from_version = ?starting_version,
+            to_version = ?ending_version,
+            "Alerting processor starting"
+        );
 
-        // Canonicalize module addresses once. Both the server-side filter
-        // compiler and the client-side extractor must see the same form,
-        // or the gRPC stream and the matcher will disagree about which
-        // events are interesting.
+        // Both the server-side filter compiler and the client-side extractor
+        // must see the same address form, or they disagree about which events
+        // match.
         let canonical_rules: Vec<_> = alerting
             .rules
             .iter()

--- a/processor/src/alerting/alerting_processor.rs
+++ b/processor/src/alerting/alerting_processor.rs
@@ -2,18 +2,13 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::{
-    alerting_dispatcher::AlertDispatcherStep,
-    alerting_extractor::AlertingExtractorStep,
-    app_config::AlertingAppConfig,
-    filter_compiler::compile_transaction_filter,
-    sinks::build_sinks,
+    alerting_dispatcher::AlertDispatcherStep, alerting_extractor::AlertingExtractorStep,
+    app_config::AlertingAppConfig, filter_compiler::compile_transaction_filter, sinks::build_sinks,
 };
 use crate::utils::counters::log_match_counter_summary;
 use anyhow::{Result, bail};
 use aptos_indexer_processor_sdk::{
-    aptos_indexer_transaction_stream::{
-        TransactionStreamConfig, transaction_stream::get_chain_id,
-    },
+    aptos_indexer_transaction_stream::{TransactionStreamConfig, transaction_stream::get_chain_id},
     builder::ProcessorBuilder,
     common_steps::TransactionStreamStep,
     traits::{IntoRunnableStep, processor_trait::ProcessorTrait},
@@ -105,7 +100,8 @@ impl ProcessorTrait for AlertingProcessor {
         })
         .await?;
 
-        let extractor = AlertingExtractorStep::new(canonical_rules, alerting.instance_label.clone());
+        let extractor =
+            AlertingExtractorStep::new(canonical_rules, alerting.instance_label.clone());
 
         let sink_handles = build_sinks(&alerting.instance_label)?;
         let dispatcher = AlertDispatcherStep::new(

--- a/processor/src/alerting/alerting_processor.rs
+++ b/processor/src/alerting/alerting_processor.rs
@@ -1,0 +1,147 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use super::{
+    alerting_dispatcher::AlertDispatcherStep,
+    alerting_extractor::AlertingExtractorStep,
+    app_config::AlertingAppConfig,
+    filter_compiler::compile_transaction_filter,
+    sinks::build_sinks,
+};
+use crate::utils::counters::log_match_counter_summary;
+use anyhow::{Result, bail};
+use aptos_indexer_processor_sdk::{
+    aptos_indexer_transaction_stream::{
+        TransactionStreamConfig, transaction_stream::get_chain_id,
+    },
+    builder::ProcessorBuilder,
+    common_steps::TransactionStreamStep,
+    traits::{IntoRunnableStep, processor_trait::ProcessorTrait},
+    utils::convert::standardize_address,
+};
+use tracing::{debug, info};
+
+/// Live-first alerting application. Reads the transaction stream and
+/// fans matches out to configured sinks (Prometheus, webhooks). Owns no
+/// durable storage of its own: there is no checkpoint table and no
+/// `VersionTrackerStep` — extended downtime is handled by an
+/// operator-driven replay deploy, not by checkpoint resume (see
+/// `AlertingProcessorConfig::{from_version,to_version,instance_label}`).
+pub struct AlertingProcessor {
+    config: AlertingAppConfig,
+}
+
+impl AlertingProcessor {
+    pub async fn new(config: AlertingAppConfig) -> Result<Self> {
+        if config.alerting_config.rules.is_empty() {
+            bail!("alerting processor requires at least one rule — `rules` is empty");
+        }
+        config.alerting_config.validate()?;
+        Ok(Self { config })
+    }
+}
+
+#[async_trait::async_trait]
+impl ProcessorTrait for AlertingProcessor {
+    fn name(&self) -> &'static str {
+        "alerting"
+    }
+
+    async fn run_processor(&self) -> Result<()> {
+        let alerting = &self.config.alerting_config;
+
+        // Verify the gRPC stream is on the chain this config is bound to.
+        // Catches misconfigured creds / endpoints before any alert metric
+        // gets a single tick under the wrong instance label.
+        let actual_chain_id = get_chain_id(self.config.transaction_stream_config.clone()).await?;
+        if actual_chain_id != alerting.chain_id {
+            bail!(
+                "chain id mismatch: config says {}, gRPC stream reports {}",
+                alerting.chain_id,
+                actual_chain_id,
+            );
+        }
+
+        // Live mode: from_version=None -> server-side default (current
+        // tip on the Aptos data service, same path get_chain_id uses).
+        // The pipeline-lag gauge will reveal it immediately if the
+        // server lands far behind tip.
+        let starting_version = alerting.from_version;
+        let ending_version = alerting.to_version;
+
+        match starting_version {
+            None => info!(
+                instance = alerting.instance_label.as_str(),
+                "Alerting processor starting at chain tip (no from_version set)"
+            ),
+            Some(from) => info!(
+                instance = alerting.instance_label.as_str(),
+                from_version = from,
+                to_version = ending_version,
+                "Alerting processor starting in replay mode"
+            ),
+        }
+
+        // Canonicalize module addresses once. Both the server-side filter
+        // compiler and the client-side extractor must see the same form,
+        // or the gRPC stream and the matcher will disagree about which
+        // events are interesting.
+        let canonical_rules: Vec<_> = alerting
+            .rules
+            .iter()
+            .map(|r| {
+                let mut r = r.clone();
+                r.module_address = standardize_address(&r.module_address);
+                r
+            })
+            .collect();
+
+        let transaction_filter = Some(compile_transaction_filter(&canonical_rules)?);
+        let transaction_stream = TransactionStreamStep::new(TransactionStreamConfig {
+            starting_version,
+            request_ending_version: ending_version,
+            transaction_filter,
+            ..self.config.transaction_stream_config.clone()
+        })
+        .await?;
+
+        let extractor = AlertingExtractorStep::new(canonical_rules, alerting.instance_label.clone());
+
+        let sink_handles = build_sinks(&alerting.instance_label)?;
+        let dispatcher = AlertDispatcherStep::new(
+            sink_handles,
+            alerting.max_alert_age_secs,
+            alerting.instance_label.clone(),
+        );
+
+        let channel_size = alerting.channel_size;
+        let (_, buffer_receiver) = ProcessorBuilder::new_with_inputless_first_step(
+            transaction_stream.into_runnable_step(),
+        )
+        .connect_to(extractor.into_runnable_step(), channel_size)
+        .connect_to(dispatcher.into_runnable_step(), channel_size)
+        .end_and_return_output_receiver(channel_size);
+
+        info!(
+            instance = alerting.instance_label.as_str(),
+            "Alerting processor pipeline started"
+        );
+
+        loop {
+            match buffer_receiver.recv().await {
+                Ok(ctx) => {
+                    debug!(
+                        start = ctx.metadata.start_version,
+                        end = ctx.metadata.end_version,
+                        "Alerting batch processed"
+                    );
+                },
+                Err(e) => {
+                    log_match_counter_summary(&alerting.instance_label);
+                    info!(error = ?e, "Alerting pipeline channel closed, shutting down");
+                    break Ok(());
+                },
+            }
+        }
+    }
+}

--- a/processor/src/alerting/alerting_processor.rs
+++ b/processor/src/alerting/alerting_processor.rs
@@ -23,11 +23,17 @@ pub struct AlertingProcessor {
 }
 
 impl AlertingProcessor {
-    pub async fn new(config: AlertingAppConfig) -> Result<Self> {
+    pub async fn new(mut config: AlertingAppConfig) -> Result<Self> {
         if config.alerting_config.rules.is_empty() {
             bail!("alerting processor requires at least one rule — `rules` is empty");
         }
         config.alerting_config.validate()?;
+        // Canonicalize module addresses so the server-side filter compiler
+        // and client-side extractor see the same form and exact-match doesn't
+        // drift between them.
+        for rule in &mut config.alerting_config.rules {
+            rule.module_address = standardize_address(&rule.module_address);
+        }
         Ok(Self { config })
     }
 }
@@ -60,20 +66,7 @@ impl ProcessorTrait for AlertingProcessor {
             "Alerting processor starting"
         );
 
-        // Both the server-side filter compiler and the client-side extractor
-        // must see the same address form, or they disagree about which events
-        // match.
-        let canonical_rules: Vec<_> = alerting
-            .rules
-            .iter()
-            .map(|r| {
-                let mut r = r.clone();
-                r.module_address = standardize_address(&r.module_address);
-                r
-            })
-            .collect();
-
-        let transaction_filter = Some(compile_transaction_filter(&canonical_rules)?);
+        let transaction_filter = Some(compile_transaction_filter(&alerting.rules)?);
         let transaction_stream = TransactionStreamStep::new(TransactionStreamConfig {
             starting_version,
             request_ending_version: ending_version,
@@ -83,7 +76,7 @@ impl ProcessorTrait for AlertingProcessor {
         .await?;
 
         let extractor =
-            AlertingExtractorStep::new(canonical_rules, alerting.instance_label.clone());
+            AlertingExtractorStep::new(alerting.rules.clone(), alerting.instance_label.clone());
 
         let sink_handles = build_sinks(&alerting.instance_label)?;
         let dispatcher = AlertDispatcherStep::new(

--- a/processor/src/alerting/app_config.rs
+++ b/processor/src/alerting/app_config.rs
@@ -10,12 +10,8 @@ use aptos_indexer_processor_sdk::{
 use serde::{Deserialize, Serialize};
 
 /// Top-level YAML shape for the alerting application. Peer to
-/// `IndexerProcessorConfig`: the alerting application reads the
-/// transaction stream and emits signals (Prometheus counters, webhooks)
-/// instead of writing data to storage. Consequently it has no
-/// `processor_mode`, no `db_config`, and no `progress_health_config` —
-/// it owns no schema, writes no checkpoint, and is exempt from
-/// progress-based health checking.
+/// `IndexerProcessorConfig`; emits signals instead of writing storage,
+/// so it has no `db_config` / `processor_mode` / `progress_health_config`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AlertingAppConfig {

--- a/processor/src/alerting/app_config.rs
+++ b/processor/src/alerting/app_config.rs
@@ -1,0 +1,36 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use super::{alerting_processor::AlertingProcessor, config::AlertingProcessorConfig};
+use anyhow::Result;
+use aptos_indexer_processor_sdk::{
+    aptos_indexer_transaction_stream::TransactionStreamConfig, server_framework::RunnableConfig,
+    traits::processor_trait::ProcessorTrait,
+};
+use serde::{Deserialize, Serialize};
+
+/// Top-level YAML shape for the alerting application. Peer to
+/// `IndexerProcessorConfig`: the alerting application reads the
+/// transaction stream and emits signals (Prometheus counters, webhooks)
+/// instead of writing data to storage. Consequently it has no
+/// `processor_mode`, no `db_config`, and no `progress_health_config` —
+/// it owns no schema, writes no checkpoint, and is exempt from
+/// progress-based health checking.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct AlertingAppConfig {
+    pub alerting_config: AlertingProcessorConfig,
+    pub transaction_stream_config: TransactionStreamConfig,
+}
+
+#[async_trait::async_trait]
+impl RunnableConfig for AlertingAppConfig {
+    async fn run(&self) -> Result<()> {
+        let processor = AlertingProcessor::new(self.clone()).await?;
+        processor.run_processor().await
+    }
+
+    fn get_server_name(&self) -> String {
+        "alerting".to_string()
+    }
+}

--- a/processor/src/alerting/config.rs
+++ b/processor/src/alerting/config.rs
@@ -1,0 +1,305 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::{
+    alerting::event_match::is_u128_parseable,
+    processors::event_file::event_file_config::SingleEventFilter,
+};
+use anyhow::{Result, bail};
+use serde::{Deserialize, Serialize};
+
+// NOTE: `AlertRule` does NOT use `#[serde(flatten)]` to embed
+// `SingleEventFilter`. serde silently disables `deny_unknown_fields` when a
+// struct also has a flattened child, which would let a typo like
+// `moduel_name` deserialize to `None` — silently broadening the rule's
+// scope to every module at the address. For an alerting system that's a
+// recipe for alert storms or missed pages. We inline the fields here and
+// expose a `to_event_filter()` helper for the matcher.
+
+const fn default_channel_size() -> usize {
+    10
+}
+
+const fn default_max_alert_age_secs() -> u64 {
+    300
+}
+
+fn default_instance_label() -> String {
+    "live".to_string()
+}
+
+pub const PROMETHEUS_SINK_NAME: &str = "prometheus";
+
+/// Top-level config for the alerting processor.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct AlertingProcessorConfig {
+    pub rules: Vec<AlertRule>,
+
+    /// Drop matched events whose block timestamp is older than this many
+    /// seconds. Defensive guard: in live mode this should rarely trigger
+    /// because the processor starts at tip and pages near-real-time; in
+    /// replay mode operators typically set this to `0` to disable the
+    /// check.
+    #[serde(default = "default_max_alert_age_secs")]
+    pub max_alert_age_secs: u64,
+
+    #[serde(default = "default_channel_size")]
+    pub channel_size: usize,
+
+    /// Inclusive start version for the alerting stream. If `None`, the
+    /// processor starts at the chain's current tip (live mode). Set to a
+    /// concrete version for replay runs.
+    #[serde(default)]
+    pub from_version: Option<u64>,
+
+    /// Inclusive end version. If `None`, the processor runs forever (live
+    /// mode). Set to a concrete version for replay runs; the processor
+    /// terminates when the stream reaches this version.
+    #[serde(default)]
+    pub to_version: Option<u64>,
+
+    /// Label attached to every alerting metric emitted by this deployment.
+    /// Defaults to `"live"`. Replay deployments should set this to a
+    /// distinct value (e.g. `"replay-2026-05-18"`) so PromQL can
+    /// distinguish replay activity from real-time signal.
+    #[serde(default = "default_instance_label")]
+    pub instance_label: String,
+
+    /// Chain ID this config is bound to. Bails at startup if the gRPC
+    /// stream reports a different value.
+    pub chain_id: u64,
+}
+
+impl AlertingProcessorConfig {
+    /// Reject configs that would silently never fire. Today this means:
+    /// `gt/gte/lt/lte` ops whose `value:` can't parse as `u128` — a typo
+    /// like `value: "abc"` or `value: -1` against a Move integer field.
+    /// Caught here so the operator sees the problem at startup instead
+    /// of staring at a flat metric line later.
+    pub fn validate(&self) -> Result<()> {
+        for rule in &self.rules {
+            for cond in &rule.conditions {
+                let needs_numeric = matches!(
+                    cond.op,
+                    CondOp::Gt | CondOp::Gte | CondOp::Lt | CondOp::Lte
+                );
+                if needs_numeric && !is_u128_parseable(&cond.value) {
+                    bail!(
+                        "rule '{}': condition on path '{}' uses numeric op {:?} \
+                         but value {} is not a u128 (use a string or non-negative \
+                         JSON integer within u128 range)",
+                        rule.name,
+                        cond.path,
+                        cond.op,
+                        cond.value,
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// A single alerting rule. Matches on-chain events by Move struct tag,
+/// optionally narrows further with payload conditions, and fans out to
+/// one or more named sinks.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct AlertRule {
+    /// Human-readable identifier used in metric labels and webhook payloads.
+    pub name: String,
+
+    /// The account address that published the module, e.g. `"0x1"`.
+    pub module_address: String,
+
+    /// If set, only match events from this module within the address.
+    #[serde(default)]
+    pub module_name: Option<String>,
+
+    /// If set, only match this specific event struct name.
+    #[serde(default)]
+    pub event_name: Option<String>,
+
+    /// Optional conditions on the event's JSON payload. All conditions must
+    /// pass (AND) for the rule to fire. Empty = match every event of the
+    /// configured type.
+    #[serde(default)]
+    pub conditions: Vec<EventCondition>,
+
+    /// Numeric payload fields (dot-paths) to expose to Prometheus as
+    /// value-accumulator counters. Each match increments
+    /// `event_field_value_total{rule, field}` by the parsed `u128` value
+    /// of the field. Use this to enable Grafana alerts like
+    /// `sum(increase(...{field="withdraw_amount"}[30m])) > T`. Fields that
+    /// fail to parse as `u128` are recorded in
+    /// `event_field_parse_errors_total{rule, field}` and skipped.
+    #[serde(default)]
+    pub emit_field_values: Vec<String>,
+
+    /// Names of sinks to deliver matches to. Defaults to `["prometheus"]`.
+    /// v1 only ships the prometheus sink; richer sink kinds arrive in a
+    /// follow-up.
+    #[serde(default = "default_sinks")]
+    pub sinks: Vec<String>,
+}
+
+impl AlertRule {
+    /// View the rule's address/module/event triple as a
+    /// `SingleEventFilter` so the existing `event_matches_filter` helper
+    /// can be reused without owning a flattened field.
+    pub fn to_event_filter(&self) -> SingleEventFilter {
+        SingleEventFilter {
+            module_address: self.module_address.clone(),
+            module_name: self.module_name.clone(),
+            event_name: self.event_name.clone(),
+        }
+    }
+}
+
+/// A predicate over a field inside the event's decoded JSON payload.
+///
+/// Path is dot-notation against the payload root: `"withdraw_amount"`,
+/// `"asset_type.inner"`, `"__variant__"`.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct EventCondition {
+    pub path: String,
+    pub op: CondOp,
+    /// JSON literal for the comparison value. Strings are matched textually;
+    /// for `gt/gte/lt/lte` the field and value are both parsed as `u128`
+    /// (Move integers arrive as strings) so `"withdraw_amount" gt "100000000"`
+    /// works as expected.
+    pub value: serde_json::Value,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CondOp {
+    Eq,
+    Ne,
+    Gt,
+    Gte,
+    Lt,
+    Lte,
+}
+
+fn default_sinks() -> Vec<String> {
+    vec![PROMETHEUS_SINK_NAME.to_string()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn cfg_with(conditions: Vec<EventCondition>) -> AlertingProcessorConfig {
+        AlertingProcessorConfig {
+            rules: vec![AlertRule {
+                name: "r".to_string(),
+                module_address: "0x1".to_string(),
+                module_name: Some("coin".to_string()),
+                event_name: Some("WithdrawEvent".to_string()),
+                conditions,
+                emit_field_values: vec![],
+                sinks: vec![PROMETHEUS_SINK_NAME.to_string()],
+            }],
+            max_alert_age_secs: 300,
+            channel_size: 10,
+            from_version: None,
+            to_version: None,
+            instance_label: "test".to_string(),
+            chain_id: 1,
+        }
+    }
+
+    fn cond(op: CondOp, value: serde_json::Value) -> EventCondition {
+        EventCondition {
+            path: "withdraw_amount".to_string(),
+            op,
+            value,
+        }
+    }
+
+    #[test]
+    fn validate_accepts_numeric_string_for_gt() {
+        cfg_with(vec![cond(CondOp::Gt, json!("100"))])
+            .validate()
+            .expect("string-encoded u128 should validate");
+    }
+
+    #[test]
+    fn validate_accepts_json_number_for_gt() {
+        cfg_with(vec![cond(CondOp::Gte, json!(100))])
+            .validate()
+            .expect("JSON number within u128 range should validate");
+    }
+
+    #[test]
+    fn validate_rejects_non_numeric_value_for_gt() {
+        let err = cfg_with(vec![cond(CondOp::Gt, json!("abc"))])
+            .validate()
+            .expect_err("non-numeric string should be rejected for gt");
+        assert!(err.to_string().contains("withdraw_amount"));
+    }
+
+    #[test]
+    fn validate_rejects_negative_value_for_gt() {
+        let err = cfg_with(vec![cond(CondOp::Lt, json!(-1))])
+            .validate()
+            .expect_err("negative value should be rejected for lt");
+        assert!(err.to_string().contains("Lt"));
+    }
+
+    #[test]
+    fn validate_ignores_non_numeric_value_for_eq() {
+        // Eq/Ne don't require numeric parsing; arbitrary JSON is fine.
+        cfg_with(vec![cond(CondOp::Eq, json!("V1"))])
+            .validate()
+            .expect("Eq on a string value should validate");
+        cfg_with(vec![cond(CondOp::Ne, json!({"nested": "object"}))])
+            .validate()
+            .expect("Ne on a structured value should validate");
+    }
+
+    #[test]
+    fn alert_rule_rejects_unknown_top_level_fields() {
+        // Regression: previously `event_filter: SingleEventFilter` was
+        // flattened into AlertRule, which silently disables
+        // `deny_unknown_fields`. A typo like `moduel_name` would then
+        // deserialize to None and the rule would silently match every
+        // module at the address — alert-storm fuel. Now that the filter
+        // fields are inlined directly, serde catches the typo.
+        let err = serde_json::from_value::<AlertRule>(json!({
+            "name": "rule",
+            "module_address": "0x1",
+            "moduel_name": "coin",
+            "event_name": "WithdrawEvent",
+        }))
+        .expect_err("typoed module_name must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("moduel_name") || msg.contains("unknown field"),
+            "expected unknown-field error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn alert_rule_accepts_well_formed_flat_yaml() {
+        // The shape operators write is still flat: rule.name +
+        // module_address/module_name/event_name siblings.
+        let r: AlertRule = serde_json::from_value(json!({
+            "name": "rule",
+            "module_address": "0x1",
+            "module_name": "coin",
+            "event_name": "WithdrawEvent",
+        }))
+        .expect("well-formed rule should parse");
+        assert_eq!(r.module_name.as_deref(), Some("coin"));
+        assert_eq!(r.event_name.as_deref(), Some("WithdrawEvent"));
+        // And the filter view round-trips into the matcher's expected shape.
+        let f = r.to_event_filter();
+        assert_eq!(f.module_address, "0x1");
+        assert_eq!(f.module_name.as_deref(), Some("coin"));
+    }
+}

--- a/processor/src/alerting/config.rs
+++ b/processor/src/alerting/config.rs
@@ -62,9 +62,16 @@ pub struct AlertingProcessorConfig {
 
 impl AlertingProcessorConfig {
     /// Catch configs that look fine but silently never fire: numeric ops
-    /// against non-`u128` values, rules referencing unknown sink names, and
-    /// duplicate rule names (which would collide on metric labels).
+    /// against non-`u128` values, rules referencing unknown sink names,
+    /// duplicate rule names (which would collide on metric labels), and
+    /// inverted replay windows.
     pub fn validate(&self) -> Result<()> {
+        if let (Some(from), Some(to)) = (self.from_version, self.to_version)
+            && from > to
+        {
+            bail!("from_version ({from}) must be <= to_version ({to})");
+        }
+
         let mut seen_names = HashSet::with_capacity(self.rules.len());
         for rule in &self.rules {
             if !seen_names.insert(rule.name.as_str()) {
@@ -267,6 +274,29 @@ mod tests {
             .validate()
             .expect_err("duplicate rule names must be rejected");
         assert!(err.to_string().contains("duplicate rule name"));
+    }
+
+    #[test]
+    fn validate_rejects_inverted_replay_window() {
+        let mut cfg = cfg_with(vec![]);
+        cfg.from_version = Some(200);
+        cfg.to_version = Some(100);
+        let err = cfg
+            .validate()
+            .expect_err("from_version > to_version must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("from_version") && msg.contains("to_version"),
+            "expected version-window error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_equal_from_and_to_version() {
+        let mut cfg = cfg_with(vec![]);
+        cfg.from_version = Some(100);
+        cfg.to_version = Some(100);
+        cfg.validate().expect("single-version replay should validate");
     }
 
     #[test]

--- a/processor/src/alerting/config.rs
+++ b/processor/src/alerting/config.rs
@@ -8,13 +8,10 @@ use crate::{
 use anyhow::{Result, bail};
 use serde::{Deserialize, Serialize};
 
-// NOTE: `AlertRule` does NOT use `#[serde(flatten)]` to embed
-// `SingleEventFilter`. serde silently disables `deny_unknown_fields` when a
-// struct also has a flattened child, which would let a typo like
-// `moduel_name` deserialize to `None` — silently broadening the rule's
-// scope to every module at the address. For an alerting system that's a
-// recipe for alert storms or missed pages. We inline the fields here and
-// expose a `to_event_filter()` helper for the matcher.
+// AlertRule inlines the SingleEventFilter fields rather than using
+// #[serde(flatten)] — a flattened child silently disables
+// deny_unknown_fields, so a typo like `moduel_name` would deserialize to
+// None and broaden the rule's scope to every module at the address.
 
 const fn default_channel_size() -> usize {
     10
@@ -36,47 +33,34 @@ pub const PROMETHEUS_SINK_NAME: &str = "prometheus";
 pub struct AlertingProcessorConfig {
     pub rules: Vec<AlertRule>,
 
-    /// Drop matched events whose block timestamp is older than this many
-    /// seconds. Defensive guard: in live mode this should rarely trigger
-    /// because the processor starts at tip and pages near-real-time; in
-    /// replay mode operators typically set this to `0` to disable the
-    /// check.
+    /// Drop matches older than this many seconds. Set to 0 in replay mode
+    /// to disable.
     #[serde(default = "default_max_alert_age_secs")]
     pub max_alert_age_secs: u64,
 
     #[serde(default = "default_channel_size")]
     pub channel_size: usize,
 
-    /// Inclusive start version for the alerting stream. If `None`, the
-    /// processor starts at the chain's current tip (live mode). Set to a
-    /// concrete version for replay runs.
+    /// Inclusive start version. `None` = live mode (start at chain tip).
     #[serde(default)]
     pub from_version: Option<u64>,
 
-    /// Inclusive end version. If `None`, the processor runs forever (live
-    /// mode). Set to a concrete version for replay runs; the processor
-    /// terminates when the stream reaches this version.
+    /// Inclusive end version. `None` = run forever.
     #[serde(default)]
     pub to_version: Option<u64>,
 
-    /// Label attached to every alerting metric emitted by this deployment.
-    /// Defaults to `"live"`. Replay deployments should set this to a
-    /// distinct value (e.g. `"replay-2026-05-18"`) so PromQL can
-    /// distinguish replay activity from real-time signal.
+    /// Label on every alerting metric. Replay deployments should use a
+    /// distinct value so PromQL can separate replay from live signal.
     #[serde(default = "default_instance_label")]
     pub instance_label: String,
 
-    /// Chain ID this config is bound to. Bails at startup if the gRPC
-    /// stream reports a different value.
+    /// Chain ID this config is bound to. Bails at startup on mismatch.
     pub chain_id: u64,
 }
 
 impl AlertingProcessorConfig {
-    /// Reject configs that would silently never fire. Today this means:
-    /// `gt/gte/lt/lte` ops whose `value:` can't parse as `u128` — a typo
-    /// like `value: "abc"` or `value: -1` against a Move integer field.
-    /// Caught here so the operator sees the problem at startup instead
-    /// of staring at a flat metric line later.
+    /// Reject configs that would silently never fire — e.g. a numeric op
+    /// against a `value:` that can't parse as `u128`.
     pub fn validate(&self) -> Result<()> {
         for rule in &self.rules {
             for cond in &rule.conditions {
@@ -99,53 +83,34 @@ impl AlertingProcessorConfig {
     }
 }
 
-/// A single alerting rule. Matches on-chain events by Move struct tag,
-/// optionally narrows further with payload conditions, and fans out to
-/// one or more named sinks.
+/// A single alerting rule. Matches events by Move struct tag, optionally
+/// narrows further with payload conditions, and fans out to named sinks.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct AlertRule {
-    /// Human-readable identifier used in metric labels and webhook payloads.
     pub name: String,
-
-    /// The account address that published the module, e.g. `"0x1"`.
     pub module_address: String,
-
-    /// If set, only match events from this module within the address.
     #[serde(default)]
     pub module_name: Option<String>,
-
-    /// If set, only match this specific event struct name.
     #[serde(default)]
     pub event_name: Option<String>,
 
-    /// Optional conditions on the event's JSON payload. All conditions must
-    /// pass (AND) for the rule to fire. Empty = match every event of the
-    /// configured type.
+    /// Conditions on the event's JSON payload (AND). Empty = match every
+    /// event of the configured type.
     #[serde(default)]
     pub conditions: Vec<EventCondition>,
 
-    /// Numeric payload fields (dot-paths) to expose to Prometheus as
-    /// value-accumulator counters. Each match increments
-    /// `event_field_value_total{rule, field}` by the parsed `u128` value
-    /// of the field. Use this to enable Grafana alerts like
-    /// `sum(increase(...{field="withdraw_amount"}[30m])) > T`. Fields that
-    /// fail to parse as `u128` are recorded in
-    /// `event_field_parse_errors_total{rule, field}` and skipped.
+    /// Numeric payload fields (dot-paths) summed into
+    /// `event_field_value_total{rule, field}`. Parse failures land in
+    /// `event_field_parse_errors_total`.
     #[serde(default)]
     pub emit_field_values: Vec<String>,
 
-    /// Names of sinks to deliver matches to. Defaults to `["prometheus"]`.
-    /// v1 only ships the prometheus sink; richer sink kinds arrive in a
-    /// follow-up.
     #[serde(default = "default_sinks")]
     pub sinks: Vec<String>,
 }
 
 impl AlertRule {
-    /// View the rule's address/module/event triple as a
-    /// `SingleEventFilter` so the existing `event_matches_filter` helper
-    /// can be reused without owning a flattened field.
     pub fn to_event_filter(&self) -> SingleEventFilter {
         SingleEventFilter {
             module_address: self.module_address.clone(),
@@ -155,19 +120,14 @@ impl AlertRule {
     }
 }
 
-/// A predicate over a field inside the event's decoded JSON payload.
-///
-/// Path is dot-notation against the payload root: `"withdraw_amount"`,
-/// `"asset_type.inner"`, `"__variant__"`.
+/// Predicate over a dot-path field in the event's JSON payload. For
+/// `gt/gte/lt/lte` both sides are parsed as `u128` (Move integers arrive
+/// as strings).
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct EventCondition {
     pub path: String,
     pub op: CondOp,
-    /// JSON literal for the comparison value. Strings are matched textually;
-    /// for `gt/gte/lt/lte` the field and value are both parsed as `u128`
-    /// (Move integers arrive as strings) so `"withdraw_amount" gt "100000000"`
-    /// works as expected.
     pub value: serde_json::Value,
 }
 
@@ -262,12 +222,7 @@ mod tests {
 
     #[test]
     fn alert_rule_rejects_unknown_top_level_fields() {
-        // Regression: previously `event_filter: SingleEventFilter` was
-        // flattened into AlertRule, which silently disables
-        // `deny_unknown_fields`. A typo like `moduel_name` would then
-        // deserialize to None and the rule would silently match every
-        // module at the address — alert-storm fuel. Now that the filter
-        // fields are inlined directly, serde catches the typo.
+        // Regression guard for the flatten-vs-deny_unknown_fields footgun.
         let err = serde_json::from_value::<AlertRule>(json!({
             "name": "rule",
             "module_address": "0x1",
@@ -284,8 +239,6 @@ mod tests {
 
     #[test]
     fn alert_rule_accepts_well_formed_flat_yaml() {
-        // The shape operators write is still flat: rule.name +
-        // module_address/module_name/event_name siblings.
         let r: AlertRule = serde_json::from_value(json!({
             "name": "rule",
             "module_address": "0x1",

--- a/processor/src/alerting/config.rs
+++ b/processor/src/alerting/config.rs
@@ -296,7 +296,8 @@ mod tests {
         let mut cfg = cfg_with(vec![]);
         cfg.from_version = Some(100);
         cfg.to_version = Some(100);
-        cfg.validate().expect("single-version replay should validate");
+        cfg.validate()
+            .expect("single-version replay should validate");
     }
 
     #[test]

--- a/processor/src/alerting/config.rs
+++ b/processor/src/alerting/config.rs
@@ -9,6 +9,9 @@ use anyhow::{Result, bail};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
+pub const PROMETHEUS_SINK_NAME: &str = "prometheus";
+const KNOWN_SINK_NAMES: &[&str] = &[PROMETHEUS_SINK_NAME];
+
 // AlertRule inlines the SingleEventFilter fields rather than using
 // #[serde(flatten)] — a flattened child silently disables
 // deny_unknown_fields, so a typo like `moduel_name` would deserialize to
@@ -25,8 +28,6 @@ const fn default_max_alert_age_secs() -> u64 {
 fn default_instance_label() -> String {
     "live".to_string()
 }
-
-pub const PROMETHEUS_SINK_NAME: &str = "prometheus";
 
 /// Top-level config for the alerting processor.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -61,9 +62,15 @@ pub struct AlertingProcessorConfig {
 
 impl AlertingProcessorConfig {
     /// Catch configs that look fine but silently never fire: numeric ops
-    /// against non-`u128` values, and rules referencing unknown sink names.
+    /// against non-`u128` values, rules referencing unknown sink names, and
+    /// duplicate rule names (which would collide on metric labels).
     pub fn validate(&self) -> Result<()> {
+        let mut seen_names = HashSet::with_capacity(self.rules.len());
         for rule in &self.rules {
+            if !seen_names.insert(rule.name.as_str()) {
+                bail!("duplicate rule name '{}'", rule.name);
+            }
+
             for cond in &rule.conditions {
                 let needs_numeric =
                     matches!(cond.op, CondOp::Gt | CondOp::Gte | CondOp::Lt | CondOp::Lte);
@@ -79,31 +86,20 @@ impl AlertingProcessorConfig {
                     );
                 }
             }
-        }
 
-        let known = self.known_sink_names();
-        for rule in &self.rules {
             for sink_name in &rule.sinks {
-                if !known.contains(sink_name.as_str()) {
-                    let mut names: Vec<&str> = known.iter().copied().collect();
-                    names.sort_unstable();
+                if !KNOWN_SINK_NAMES.contains(&sink_name.as_str()) {
                     bail!(
                         "rule '{}': references unknown sink '{}' (known sinks: {:?})",
                         rule.name,
                         sink_name,
-                        names,
+                        KNOWN_SINK_NAMES,
                     );
                 }
             }
         }
 
         Ok(())
-    }
-
-    fn known_sink_names(&self) -> HashSet<&str> {
-        let mut names = HashSet::new();
-        names.insert(PROMETHEUS_SINK_NAME);
-        names
     }
 }
 
@@ -261,6 +257,16 @@ mod tests {
         let mut cfg = cfg_with(vec![]);
         cfg.rules[0].sinks = vec![PROMETHEUS_SINK_NAME.to_string()];
         cfg.validate().expect("prometheus is always a known sink");
+    }
+
+    #[test]
+    fn validate_rejects_duplicate_rule_names() {
+        let mut cfg = cfg_with(vec![]);
+        cfg.rules.push(cfg.rules[0].clone());
+        let err = cfg
+            .validate()
+            .expect_err("duplicate rule names must be rejected");
+        assert!(err.to_string().contains("duplicate rule name"));
     }
 
     #[test]

--- a/processor/src/alerting/config.rs
+++ b/processor/src/alerting/config.rs
@@ -80,10 +80,8 @@ impl AlertingProcessorConfig {
     pub fn validate(&self) -> Result<()> {
         for rule in &self.rules {
             for cond in &rule.conditions {
-                let needs_numeric = matches!(
-                    cond.op,
-                    CondOp::Gt | CondOp::Gte | CondOp::Lt | CondOp::Lte
-                );
+                let needs_numeric =
+                    matches!(cond.op, CondOp::Gt | CondOp::Gte | CondOp::Lt | CondOp::Lte);
                 if needs_numeric && !is_u128_parseable(&cond.value) {
                     bail!(
                         "rule '{}': condition on path '{}' uses numeric op {:?} \

--- a/processor/src/alerting/config.rs
+++ b/processor/src/alerting/config.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use anyhow::{Result, bail};
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 
 // AlertRule inlines the SingleEventFilter fields rather than using
 // #[serde(flatten)] — a flattened child silently disables
@@ -59,8 +60,8 @@ pub struct AlertingProcessorConfig {
 }
 
 impl AlertingProcessorConfig {
-    /// Reject configs that would silently never fire — e.g. a numeric op
-    /// against a `value:` that can't parse as `u128`.
+    /// Catch configs that look fine but silently never fire: numeric ops
+    /// against non-`u128` values, and rules referencing unknown sink names.
     pub fn validate(&self) -> Result<()> {
         for rule in &self.rules {
             for cond in &rule.conditions {
@@ -79,7 +80,30 @@ impl AlertingProcessorConfig {
                 }
             }
         }
+
+        let known = self.known_sink_names();
+        for rule in &self.rules {
+            for sink_name in &rule.sinks {
+                if !known.contains(sink_name.as_str()) {
+                    let mut names: Vec<&str> = known.iter().copied().collect();
+                    names.sort_unstable();
+                    bail!(
+                        "rule '{}': references unknown sink '{}' (known sinks: {:?})",
+                        rule.name,
+                        sink_name,
+                        names,
+                    );
+                }
+            }
+        }
+
         Ok(())
+    }
+
+    fn known_sink_names(&self) -> HashSet<&str> {
+        let mut names = HashSet::new();
+        names.insert(PROMETHEUS_SINK_NAME);
+        names
     }
 }
 
@@ -218,6 +242,25 @@ mod tests {
         cfg_with(vec![cond(CondOp::Ne, json!({"nested": "object"}))])
             .validate()
             .expect("Ne on a structured value should validate");
+    }
+
+    #[test]
+    fn validate_rejects_rule_referencing_unknown_sink() {
+        let mut cfg = cfg_with(vec![]);
+        cfg.rules[0].sinks = vec!["prometehus".to_string()];
+        let err = cfg.validate().expect_err("typoed sink must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("prometehus") && msg.contains("unknown sink"),
+            "expected unknown-sink error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_prometheus_sink_reference() {
+        let mut cfg = cfg_with(vec![]);
+        cfg.rules[0].sinks = vec![PROMETHEUS_SINK_NAME.to_string()];
+        cfg.validate().expect("prometheus is always a known sink");
     }
 
     #[test]

--- a/processor/src/alerting/event_match.rs
+++ b/processor/src/alerting/event_match.rs
@@ -47,11 +47,7 @@ pub fn condition_matches(condition: &EventCondition, payload: &Value) -> Conditi
 
 /// Numeric op evaluation: both sides must parse as `u128` or this is a
 /// `ComparisonNonNumeric` (config-vs-payload mismatch surfaced as metric).
-fn numeric_compare(
-    lhs: &Value,
-    rhs: &Value,
-    op: impl FnOnce(u128, u128) -> bool,
-) -> ConditionEval {
+fn numeric_compare(lhs: &Value, rhs: &Value, op: impl FnOnce(u128, u128) -> bool) -> ConditionEval {
     let (Some(l), Some(r)) = (to_u128(lhs), to_u128(rhs)) else {
         return ConditionEval::ComparisonNonNumeric;
     };
@@ -189,7 +185,10 @@ mod tests {
             ConditionEval::Fail
         );
         assert_eq!(
-            condition_matches(&cond("withdraw_amount", CondOp::Gte, json!("100000000")), &p),
+            condition_matches(
+                &cond("withdraw_amount", CondOp::Gte, json!("100000000")),
+                &p
+            ),
             ConditionEval::Pass
         );
     }
@@ -254,7 +253,9 @@ mod tests {
     fn is_u128_parseable_accepts_string_and_number_forms() {
         assert!(is_u128_parseable(&json!("100")));
         assert!(is_u128_parseable(&json!(100)));
-        assert!(is_u128_parseable(&json!("340282366920938463463374607431768211455"))); // u128::MAX
+        assert!(is_u128_parseable(&json!(
+            "340282366920938463463374607431768211455"
+        ))); // u128::MAX
         assert!(!is_u128_parseable(&json!("not_a_number")));
         assert!(!is_u128_parseable(&json!(-1)));
         assert!(!is_u128_parseable(&json!(null)));

--- a/processor/src/alerting/event_match.rs
+++ b/processor/src/alerting/event_match.rs
@@ -1,0 +1,262 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use super::config::{CondOp, EventCondition};
+use serde_json::Value;
+
+/// Result of evaluating one condition. `Pass`/`Fail` are normal outcomes;
+/// `ComparisonNonNumeric` distinguishes the "I tried to compare numerically
+/// but the event-side value didn't parse as u128" case so callers can
+/// record it as a metric instead of treating it as a silent `Fail`.
+///
+/// Config-side numeric values are validated at startup (see
+/// `AlertingProcessorConfig::validate`), so at runtime
+/// `ComparisonNonNumeric` always means the event payload itself was the
+/// problem — wrong variant, missing field, or a struct where a number
+/// was expected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConditionEval {
+    Pass,
+    Fail,
+    ComparisonNonNumeric,
+}
+
+/// Evaluate the condition against a parsed event payload.
+///
+/// `payload` is the JSON-decoded `event.data`. `path` uses dot notation —
+/// `"asset_type.inner"` walks into the nested object.
+pub fn condition_matches(condition: &EventCondition, payload: &Value) -> ConditionEval {
+    let Some(field) = resolve_path(payload, &condition.path) else {
+        return ConditionEval::Fail;
+    };
+
+    let pass = match condition.op {
+        CondOp::Eq => values_equal(field, &condition.value),
+        CondOp::Ne => !values_equal(field, &condition.value),
+        CondOp::Gt => return numeric_compare(field, &condition.value, |l, r| l > r),
+        CondOp::Gte => return numeric_compare(field, &condition.value, |l, r| l >= r),
+        CondOp::Lt => return numeric_compare(field, &condition.value, |l, r| l < r),
+        CondOp::Lte => return numeric_compare(field, &condition.value, |l, r| l <= r),
+    };
+    if pass {
+        ConditionEval::Pass
+    } else {
+        ConditionEval::Fail
+    }
+}
+
+/// Numeric op evaluation: both sides must parse as `u128` or this is a
+/// `ComparisonNonNumeric` (config-vs-payload mismatch surfaced as metric).
+fn numeric_compare(
+    lhs: &Value,
+    rhs: &Value,
+    op: impl FnOnce(u128, u128) -> bool,
+) -> ConditionEval {
+    let (Some(l), Some(r)) = (to_u128(lhs), to_u128(rhs)) else {
+        return ConditionEval::ComparisonNonNumeric;
+    };
+    if op(l, r) {
+        ConditionEval::Pass
+    } else {
+        ConditionEval::Fail
+    }
+}
+
+/// Returns `true` iff the JSON value can be parsed as `u128`. Used by
+/// config-time validation to reject `gt/gte/lt/lte` rules whose `value:`
+/// can never compare against a Move integer.
+pub fn is_u128_parseable(v: &Value) -> bool {
+    to_u128(v).is_some()
+}
+
+/// Read a numeric payload field as `u128`. Move integer fields arrive as
+/// JSON strings, so this attempts string-parse first and then falls back
+/// to JSON numbers for non-Move payloads.
+pub fn read_u128_field(payload: &Value, path: &str) -> Option<u128> {
+    resolve_path(payload, path).and_then(to_u128)
+}
+
+/// Walk a JSON value via a dot-separated path. Returns `None` if any
+/// segment is missing.
+fn resolve_path<'a>(root: &'a Value, path: &str) -> Option<&'a Value> {
+    let mut current = root;
+    for segment in path.split('.') {
+        current = current.get(segment)?;
+    }
+    Some(current)
+}
+
+/// Equality semantics: strings compare by text directly; numeric coercion
+/// only kicks in when at least one side is a `Number` (so we can match a
+/// Move u64 string against a JSON `100`).
+fn values_equal(lhs: &Value, rhs: &Value) -> bool {
+    // Fast path: same-shape equality is the common case (string-string).
+    if lhs == rhs {
+        return true;
+    }
+    // Cross-type numeric coercion only matters when one side is a Number;
+    // String-String inequality stays a cheap lex compare.
+    if (matches!(lhs, Value::Number(_)) || matches!(rhs, Value::Number(_)))
+        && let (Some(l), Some(r)) = (to_u128(lhs), to_u128(rhs))
+    {
+        return l == r;
+    }
+    false
+}
+
+fn to_u128(v: &Value) -> Option<u128> {
+    match v {
+        Value::String(s) => s.parse::<u128>().ok(),
+        // serde_json::Number doesn't expose `as_u128` until 1.0.86; go via
+        // string to handle the full u128 range. Reject anything that parsed
+        // as a non-integer or negative number.
+        Value::Number(n) => {
+            if n.is_u64() {
+                return n.as_u64().map(u128::from);
+            }
+            n.to_string().parse::<u128>().ok()
+        },
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // Mirrors the user's example payload.
+    fn sample_payload() -> Value {
+        json!({
+            "__variant__": "V1",
+            "asset_from_main": "0",
+            "asset_from_paired": "100000000",
+            "asset_type": { "inner": "0xbae207659db88bea0cbead6da0ed00aac12edcdda169e591cd41c94180b46f3b" },
+            "withdraw_amount": "100000000"
+        })
+    }
+
+    fn cond(path: &str, op: CondOp, value: Value) -> EventCondition {
+        EventCondition {
+            path: path.to_string(),
+            op,
+            value,
+        }
+    }
+
+    #[test]
+    fn eq_on_string_variant() {
+        let p = sample_payload();
+        assert_eq!(
+            condition_matches(&cond("__variant__", CondOp::Eq, json!("V1")), &p),
+            ConditionEval::Pass
+        );
+        assert_eq!(
+            condition_matches(&cond("__variant__", CondOp::Eq, json!("V2")), &p),
+            ConditionEval::Fail
+        );
+    }
+
+    #[test]
+    fn eq_on_nested_path() {
+        let p = sample_payload();
+        assert_eq!(
+            condition_matches(
+                &cond(
+                    "asset_type.inner",
+                    CondOp::Eq,
+                    json!("0xbae207659db88bea0cbead6da0ed00aac12edcdda169e591cd41c94180b46f3b"),
+                ),
+                &p,
+            ),
+            ConditionEval::Pass
+        );
+        assert_eq!(
+            condition_matches(&cond("asset_type.inner", CondOp::Eq, json!("0xdead")), &p),
+            ConditionEval::Fail
+        );
+    }
+
+    #[test]
+    fn gt_on_move_string_integer() {
+        let p = sample_payload();
+        assert_eq!(
+            condition_matches(&cond("withdraw_amount", CondOp::Gt, json!("99999999")), &p),
+            ConditionEval::Pass
+        );
+        assert_eq!(
+            condition_matches(&cond("withdraw_amount", CondOp::Gt, json!("100000000")), &p),
+            ConditionEval::Fail
+        );
+        assert_eq!(
+            condition_matches(&cond("withdraw_amount", CondOp::Gte, json!("100000000")), &p),
+            ConditionEval::Pass
+        );
+    }
+
+    #[test]
+    fn missing_path_is_fail_not_compare_error() {
+        // A missing path is a normal "doesn't match" outcome regardless of
+        // op — don't conflate it with the compare-error signal.
+        let p = sample_payload();
+        assert_eq!(
+            condition_matches(&cond("nonexistent", CondOp::Eq, json!("anything")), &p),
+            ConditionEval::Fail
+        );
+        assert_eq!(
+            condition_matches(&cond("nonexistent", CondOp::Gt, json!("0")), &p),
+            ConditionEval::Fail
+        );
+    }
+
+    #[test]
+    fn ne_inverts_eq() {
+        let p = sample_payload();
+        assert_eq!(
+            condition_matches(&cond("__variant__", CondOp::Ne, json!("V2")), &p),
+            ConditionEval::Pass
+        );
+    }
+
+    #[test]
+    fn numeric_compare_against_non_numeric_field_reports_error() {
+        // `__variant__` is a string like "V1" — comparing it numerically
+        // is a config/payload-shape error, not a normal Fail.
+        let p = sample_payload();
+        assert_eq!(
+            condition_matches(&cond("__variant__", CondOp::Gt, json!("0")), &p),
+            ConditionEval::ComparisonNonNumeric
+        );
+    }
+
+    #[test]
+    fn read_u128_field_parses_move_string_integer() {
+        let p = sample_payload();
+        assert_eq!(read_u128_field(&p, "withdraw_amount"), Some(100_000_000));
+        assert_eq!(read_u128_field(&p, "asset_from_main"), Some(0));
+        assert_eq!(read_u128_field(&p, "nonexistent"), None);
+        assert_eq!(read_u128_field(&p, "__variant__"), None); // non-numeric
+    }
+
+    #[test]
+    fn cross_type_equality_normalizes_numeric_strings() {
+        // String "100" and number 100 should be equal under our semantics
+        // since Move integers always arrive as strings but configs may
+        // sensibly use JSON numbers.
+        let p = json!({ "n": "100" });
+        assert_eq!(
+            condition_matches(&cond("n", CondOp::Eq, json!(100)), &p),
+            ConditionEval::Pass
+        );
+    }
+
+    #[test]
+    fn is_u128_parseable_accepts_string_and_number_forms() {
+        assert!(is_u128_parseable(&json!("100")));
+        assert!(is_u128_parseable(&json!(100)));
+        assert!(is_u128_parseable(&json!("340282366920938463463374607431768211455"))); // u128::MAX
+        assert!(!is_u128_parseable(&json!("not_a_number")));
+        assert!(!is_u128_parseable(&json!(-1)));
+        assert!(!is_u128_parseable(&json!(null)));
+    }
+}

--- a/processor/src/alerting/event_match.rs
+++ b/processor/src/alerting/event_match.rs
@@ -4,16 +4,9 @@
 use super::config::{CondOp, EventCondition};
 use serde_json::Value;
 
-/// Result of evaluating one condition. `Pass`/`Fail` are normal outcomes;
-/// `ComparisonNonNumeric` distinguishes the "I tried to compare numerically
-/// but the event-side value didn't parse as u128" case so callers can
-/// record it as a metric instead of treating it as a silent `Fail`.
-///
-/// Config-side numeric values are validated at startup (see
-/// `AlertingProcessorConfig::validate`), so at runtime
-/// `ComparisonNonNumeric` always means the event payload itself was the
-/// problem — wrong variant, missing field, or a struct where a number
-/// was expected.
+/// `ComparisonNonNumeric` distinguishes a numeric op against a non-numeric
+/// event-side value (e.g. wrong variant) so callers can record it as a
+/// metric rather than treat it as a silent `Fail`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConditionEval {
     Pass,
@@ -21,10 +14,6 @@ pub enum ConditionEval {
     ComparisonNonNumeric,
 }
 
-/// Evaluate the condition against a parsed event payload.
-///
-/// `payload` is the JSON-decoded `event.data`. `path` uses dot notation —
-/// `"asset_type.inner"` walks into the nested object.
 pub fn condition_matches(condition: &EventCondition, payload: &Value) -> ConditionEval {
     let Some(field) = resolve_path(payload, &condition.path) else {
         return ConditionEval::Fail;
@@ -45,8 +34,6 @@ pub fn condition_matches(condition: &EventCondition, payload: &Value) -> Conditi
     }
 }
 
-/// Numeric op evaluation: both sides must parse as `u128` or this is a
-/// `ComparisonNonNumeric` (config-vs-payload mismatch surfaced as metric).
 fn numeric_compare(lhs: &Value, rhs: &Value, op: impl FnOnce(u128, u128) -> bool) -> ConditionEval {
     let (Some(l), Some(r)) = (to_u128(lhs), to_u128(rhs)) else {
         return ConditionEval::ComparisonNonNumeric;
@@ -58,22 +45,14 @@ fn numeric_compare(lhs: &Value, rhs: &Value, op: impl FnOnce(u128, u128) -> bool
     }
 }
 
-/// Returns `true` iff the JSON value can be parsed as `u128`. Used by
-/// config-time validation to reject `gt/gte/lt/lte` rules whose `value:`
-/// can never compare against a Move integer.
 pub fn is_u128_parseable(v: &Value) -> bool {
     to_u128(v).is_some()
 }
 
-/// Read a numeric payload field as `u128`. Move integer fields arrive as
-/// JSON strings, so this attempts string-parse first and then falls back
-/// to JSON numbers for non-Move payloads.
 pub fn read_u128_field(payload: &Value, path: &str) -> Option<u128> {
     resolve_path(payload, path).and_then(to_u128)
 }
 
-/// Walk a JSON value via a dot-separated path. Returns `None` if any
-/// segment is missing.
 fn resolve_path<'a>(root: &'a Value, path: &str) -> Option<&'a Value> {
     let mut current = root;
     for segment in path.split('.') {
@@ -82,16 +61,12 @@ fn resolve_path<'a>(root: &'a Value, path: &str) -> Option<&'a Value> {
     Some(current)
 }
 
-/// Equality semantics: strings compare by text directly; numeric coercion
-/// only kicks in when at least one side is a `Number` (so we can match a
-/// Move u64 string against a JSON `100`).
+/// Strings compare textually; numeric coercion only applies when at least
+/// one side is a JSON `Number` (so a Move u64 string can equal `100`).
 fn values_equal(lhs: &Value, rhs: &Value) -> bool {
-    // Fast path: same-shape equality is the common case (string-string).
     if lhs == rhs {
         return true;
     }
-    // Cross-type numeric coercion only matters when one side is a Number;
-    // String-String inequality stays a cheap lex compare.
     if (matches!(lhs, Value::Number(_)) || matches!(rhs, Value::Number(_)))
         && let (Some(l), Some(r)) = (to_u128(lhs), to_u128(rhs))
     {
@@ -103,9 +78,6 @@ fn values_equal(lhs: &Value, rhs: &Value) -> bool {
 fn to_u128(v: &Value) -> Option<u128> {
     match v {
         Value::String(s) => s.parse::<u128>().ok(),
-        // serde_json::Number doesn't expose `as_u128` until 1.0.86; go via
-        // string to handle the full u128 range. Reject anything that parsed
-        // as a non-integer or negative number.
         Value::Number(n) => {
             if n.is_u64() {
                 return n.as_u64().map(u128::from);
@@ -121,7 +93,6 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-    // Mirrors the user's example payload.
     fn sample_payload() -> Value {
         json!({
             "__variant__": "V1",
@@ -195,8 +166,6 @@ mod tests {
 
     #[test]
     fn missing_path_is_fail_not_compare_error() {
-        // A missing path is a normal "doesn't match" outcome regardless of
-        // op — don't conflate it with the compare-error signal.
         let p = sample_payload();
         assert_eq!(
             condition_matches(&cond("nonexistent", CondOp::Eq, json!("anything")), &p),
@@ -219,8 +188,6 @@ mod tests {
 
     #[test]
     fn numeric_compare_against_non_numeric_field_reports_error() {
-        // `__variant__` is a string like "V1" — comparing it numerically
-        // is a config/payload-shape error, not a normal Fail.
         let p = sample_payload();
         assert_eq!(
             condition_matches(&cond("__variant__", CondOp::Gt, json!("0")), &p),
@@ -239,9 +206,6 @@ mod tests {
 
     #[test]
     fn cross_type_equality_normalizes_numeric_strings() {
-        // String "100" and number 100 should be equal under our semantics
-        // since Move integers always arrive as strings but configs may
-        // sensibly use JSON numbers.
         let p = json!({ "n": "100" });
         assert_eq!(
             condition_matches(&cond("n", CondOp::Eq, json!(100)), &p),

--- a/processor/src/alerting/filter_compiler.rs
+++ b/processor/src/alerting/filter_compiler.rs
@@ -8,17 +8,12 @@ use aptos_indexer_processor_sdk::aptos_transaction_filter::{
     TransactionRootFilterBuilder,
 };
 
-/// Compile alert rules into a single server-side gRPC filter so the
-/// transaction stream only emits matching transactions.
+/// Compile alert rules into a server-side gRPC filter:
+/// `success AND (rule_1 OR rule_2 OR ...)`. Payload-field conditions are
+/// evaluated client-side by the extractor.
 ///
-/// The shape is `success AND (rule_1_event_match OR rule_2_event_match OR ...)`.
-/// Payload-field conditions and `emit_field_values` are not expressible at the
-/// gRPC layer and are evaluated client-side by [`super::alerting_extractor`].
-///
-/// **Assumes `rules` is already canonicalized** (module addresses
-/// standardized at `AlertingProcessor::run_processor` before either the
-/// filter compiler or the extractor sees them). Re-normalizing here
-/// would risk drift between the server filter and the client matcher.
+/// Assumes `rules` is already canonicalized — re-normalizing here would
+/// risk drift between server filter and client matcher.
 pub fn compile_transaction_filter(rules: &[AlertRule]) -> Result<BooleanTransactionFilter> {
     if rules.is_empty() {
         return Err(anyhow!(

--- a/processor/src/alerting/filter_compiler.rs
+++ b/processor/src/alerting/filter_compiler.rs
@@ -1,0 +1,68 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use super::config::AlertRule;
+use anyhow::{Context, Result, anyhow};
+use aptos_indexer_processor_sdk::aptos_transaction_filter::{
+    BooleanTransactionFilter, EventFilterBuilder, MoveStructTagFilterBuilder,
+    TransactionRootFilterBuilder,
+};
+
+/// Compile alert rules into a single server-side gRPC filter so the
+/// transaction stream only emits matching transactions.
+///
+/// The shape is `success AND (rule_1_event_match OR rule_2_event_match OR ...)`.
+/// Payload-field conditions and `emit_field_values` are not expressible at the
+/// gRPC layer and are evaluated client-side by [`super::alerting_extractor`].
+///
+/// **Assumes `rules` is already canonicalized** (module addresses
+/// standardized at `AlertingProcessor::run_processor` before either the
+/// filter compiler or the extractor sees them). Re-normalizing here
+/// would risk drift between the server filter and the client matcher.
+pub fn compile_transaction_filter(rules: &[AlertRule]) -> Result<BooleanTransactionFilter> {
+    if rules.is_empty() {
+        return Err(anyhow!(
+            "alerting processor requires at least one rule — none configured"
+        ));
+    }
+
+    let success_filter = BooleanTransactionFilter::from(
+        TransactionRootFilterBuilder::default()
+            .success(true)
+            .build()
+            .context("failed to build success filter")?,
+    );
+
+    let event_filters: Vec<BooleanTransactionFilter> = rules
+        .iter()
+        .map(|r| {
+            let mut tag = MoveStructTagFilterBuilder::default();
+            tag.address(r.module_address.clone());
+            if let Some(ref m) = r.module_name {
+                tag.module(m.clone());
+            }
+            if let Some(ref n) = r.event_name {
+                tag.name(n.clone());
+            }
+            let tag = tag
+                .build()
+                .with_context(|| format!("rule '{}': struct tag filter", r.name))?;
+            let event = EventFilterBuilder::default()
+                .struct_type(tag)
+                .build()
+                .with_context(|| format!("rule '{}': event filter", r.name))?;
+            Ok(BooleanTransactionFilter::from(event))
+        })
+        .collect::<Result<_>>()?;
+
+    let event_or = if event_filters.len() == 1 {
+        event_filters.into_iter().next().unwrap()
+    } else {
+        BooleanTransactionFilter::new_or(event_filters)
+    };
+
+    Ok(BooleanTransactionFilter::new_and(vec![
+        success_filter,
+        event_or,
+    ]))
+}

--- a/processor/src/alerting/mod.rs
+++ b/processor/src/alerting/mod.rs
@@ -1,8 +1,11 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
+pub mod alerting_dispatcher;
+pub mod alerting_extractor;
+pub mod alerting_processor;
 pub mod app_config;
-pub mod db_config;
-pub mod indexer_processor_config;
-pub mod processor_config;
-pub mod processor_mode;
+pub mod config;
+pub mod event_match;
+pub mod filter_compiler;
+pub mod sinks;

--- a/processor/src/alerting/sinks/mod.rs
+++ b/processor/src/alerting/sinks/mod.rs
@@ -7,12 +7,9 @@ use super::{alerting_extractor::MatchedEvent, config::PROMETHEUS_SINK_NAME};
 use anyhow::Result;
 use std::{collections::HashMap, sync::Arc};
 
-/// A non-blocking, fire-and-forget delivery handle for one configured sink.
-///
-/// Implementations MUST NOT block the calling task. Future network-bound
-/// sinks (webhooks, etc.) will push onto a bounded channel consumed by a
-/// background task. The sink's name is the key in the `HashMap` returned
-/// by [`build_sinks`]; no per-handle `name()` accessor is needed.
+/// Non-blocking, fire-and-forget delivery handle for one configured sink.
+/// Network-bound sinks push onto a bounded channel and increment
+/// `event_sink_dropped_total` on overflow.
 pub trait AlertSinkHandle: Send + Sync {
     fn try_deliver(&self, event: &MatchedEvent);
 }

--- a/processor/src/alerting/sinks/mod.rs
+++ b/processor/src/alerting/sinks/mod.rs
@@ -1,0 +1,32 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+pub mod prometheus;
+
+use super::{alerting_extractor::MatchedEvent, config::PROMETHEUS_SINK_NAME};
+use anyhow::Result;
+use std::{collections::HashMap, sync::Arc};
+
+/// A non-blocking, fire-and-forget delivery handle for one configured sink.
+///
+/// Implementations MUST NOT block the calling task. Future network-bound
+/// sinks (webhooks, etc.) will push onto a bounded channel consumed by a
+/// background task. The sink's name is the key in the `HashMap` returned
+/// by [`build_sinks`]; no per-handle `name()` accessor is needed.
+pub trait AlertSinkHandle: Send + Sync {
+    fn try_deliver(&self, event: &MatchedEvent);
+}
+
+/// Build all configured sink handles. The `prometheus` sink is always
+/// registered. This v1 only supports the prometheus sink; richer sink
+/// kinds (webhook, Slack, …) ship in a follow-up PR.
+pub fn build_sinks(
+    instance_label: &str,
+) -> Result<HashMap<String, Arc<dyn AlertSinkHandle>>> {
+    let mut handles: HashMap<String, Arc<dyn AlertSinkHandle>> = HashMap::new();
+    handles.insert(
+        PROMETHEUS_SINK_NAME.to_string(),
+        Arc::new(prometheus::PrometheusSink::new(instance_label.to_string())),
+    );
+    Ok(handles)
+}

--- a/processor/src/alerting/sinks/mod.rs
+++ b/processor/src/alerting/sinks/mod.rs
@@ -20,9 +20,7 @@ pub trait AlertSinkHandle: Send + Sync {
 /// Build all configured sink handles. The `prometheus` sink is always
 /// registered. This v1 only supports the prometheus sink; richer sink
 /// kinds (webhook, Slack, …) ship in a follow-up PR.
-pub fn build_sinks(
-    instance_label: &str,
-) -> Result<HashMap<String, Arc<dyn AlertSinkHandle>>> {
+pub fn build_sinks(instance_label: &str) -> Result<HashMap<String, Arc<dyn AlertSinkHandle>>> {
     let mut handles: HashMap<String, Arc<dyn AlertSinkHandle>> = HashMap::new();
     handles.insert(
         PROMETHEUS_SINK_NAME.to_string(),

--- a/processor/src/alerting/sinks/prometheus.rs
+++ b/processor/src/alerting/sinks/prometheus.rs
@@ -1,0 +1,46 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use super::AlertSinkHandle;
+use crate::{
+    alerting::alerting_extractor::MatchedEvent,
+    utils::counters::{
+        EVENT_FIELD_VALUE_OVERFLOW_TOTAL, EVENT_FIELD_VALUE_TOTAL, EVENT_MATCH_TOTAL,
+    },
+};
+
+pub struct PrometheusSink {
+    instance_label: String,
+}
+
+impl PrometheusSink {
+    pub fn new(instance_label: String) -> Self {
+        Self { instance_label }
+    }
+}
+
+impl AlertSinkHandle for PrometheusSink {
+    fn try_deliver(&self, event: &MatchedEvent) {
+        EVENT_MATCH_TOTAL
+            .with_label_values(&[&event.rule_name, &event.event_type, &self.instance_label])
+            .inc();
+
+        for (field, value) in &event.field_values {
+            // IntCounter::inc_by takes u64. Saturate u128 → u64 and record
+            // each saturation so a plateaued counter is distinguishable from
+            // genuinely flat activity.
+            let to_add = match u64::try_from(*value) {
+                Ok(v) => v,
+                Err(_) => {
+                    EVENT_FIELD_VALUE_OVERFLOW_TOTAL
+                        .with_label_values(&[&event.rule_name, field, &self.instance_label])
+                        .inc();
+                    u64::MAX
+                },
+            };
+            EVENT_FIELD_VALUE_TOTAL
+                .with_label_values(&[&event.rule_name, field, &self.instance_label])
+                .inc_by(to_add);
+        }
+    }
+}

--- a/processor/src/alerting/sinks/prometheus.rs
+++ b/processor/src/alerting/sinks/prometheus.rs
@@ -26,20 +26,91 @@ impl AlertSinkHandle for PrometheusSink {
             .inc();
 
         for (field, value) in &event.field_values {
-            // IntCounter::inc_by takes u64; saturate and count saturations
-            // so a plateaued counter is visible.
-            let to_add = match u64::try_from(*value) {
-                Ok(v) => v,
+            // inc_by(u64::MAX) wraps via fetch_add, so on overflow skip the
+            // value counter and only bump the overflow counter.
+            match u64::try_from(*value) {
+                Ok(v) => {
+                    EVENT_FIELD_VALUE_TOTAL
+                        .with_label_values(&[&event.rule_name, field, &self.instance_label])
+                        .inc_by(v);
+                },
                 Err(_) => {
                     EVENT_FIELD_VALUE_OVERFLOW_TOTAL
                         .with_label_values(&[&event.rule_name, field, &self.instance_label])
                         .inc();
-                    u64::MAX
                 },
-            };
-            EVENT_FIELD_VALUE_TOTAL
-                .with_label_values(&[&event.rule_name, field, &self.instance_label])
-                .inc_by(to_add);
+            }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::sync::Arc;
+
+    fn matched(field_values: Vec<(String, u128)>, instance: &str) -> MatchedEvent {
+        MatchedEvent {
+            rule_name: "test_rule".to_string(),
+            event_type: "test::type".to_string(),
+            version: 1,
+            timestamp_secs: 0,
+            payload: Arc::new(json!({})),
+            field_values,
+            sinks: vec!["prometheus".to_string()],
+        }
+    }
+
+    // Regression: inc_by(u64::MAX) wraps, so non-zero counter would
+    // decrement. Overflow path must skip the value counter entirely.
+    #[test]
+    fn overflow_does_not_regress_value_counter() {
+        let instance = format!(
+            "prom_overflow_{}",
+            chrono::Utc::now().timestamp_nanos_opt().unwrap()
+        );
+        let sink = PrometheusSink::new(instance.clone());
+        let field = "amount".to_string();
+
+        // Prime the counter to a known non-zero value.
+        sink.try_deliver(&matched(vec![(field.clone(), 100u128)], &instance));
+        let before = EVENT_FIELD_VALUE_TOTAL
+            .with_label_values(&["test_rule", "amount", &instance])
+            .get();
+        assert_eq!(before, 100);
+
+        // Deliver a value above u64::MAX. The value counter must NOT change;
+        // the overflow counter must increment by 1.
+        let huge = u128::from(u64::MAX) + 1;
+        sink.try_deliver(&matched(vec![(field.clone(), huge)], &instance));
+
+        let after = EVENT_FIELD_VALUE_TOTAL
+            .with_label_values(&["test_rule", "amount", &instance])
+            .get();
+        let overflows = EVENT_FIELD_VALUE_OVERFLOW_TOTAL
+            .with_label_values(&["test_rule", "amount", &instance])
+            .get();
+        assert_eq!(
+            after,
+            before,
+            "overflow must not touch the value counter (wrap would give {})",
+            before.wrapping_sub(1)
+        );
+        assert_eq!(overflows, 1, "expected one overflow increment");
+    }
+
+    #[test]
+    fn normal_value_increments_value_counter() {
+        let instance = format!(
+            "prom_normal_{}",
+            chrono::Utc::now().timestamp_nanos_opt().unwrap()
+        );
+        let sink = PrometheusSink::new(instance.clone());
+        sink.try_deliver(&matched(vec![("amount".to_string(), 42u128)], &instance));
+        let value = EVENT_FIELD_VALUE_TOTAL
+            .with_label_values(&["test_rule", "amount", &instance])
+            .get();
+        assert_eq!(value, 42);
     }
 }

--- a/processor/src/alerting/sinks/prometheus.rs
+++ b/processor/src/alerting/sinks/prometheus.rs
@@ -26,9 +26,8 @@ impl AlertSinkHandle for PrometheusSink {
             .inc();
 
         for (field, value) in &event.field_values {
-            // IntCounter::inc_by takes u64. Saturate u128 → u64 and record
-            // each saturation so a plateaued counter is distinguishable from
-            // genuinely flat activity.
+            // IntCounter::inc_by takes u64; saturate and count saturations
+            // so a plateaued counter is visible.
             let to_add = match u64::try_from(*value) {
                 Ok(v) => v,
                 Err(_) => {

--- a/processor/src/alerting/sinks/prometheus.rs
+++ b/processor/src/alerting/sinks/prometheus.rs
@@ -50,7 +50,7 @@ mod tests {
     use serde_json::json;
     use std::sync::Arc;
 
-    fn matched(field_values: Vec<(String, u128)>, instance: &str) -> MatchedEvent {
+    fn matched(field_values: Vec<(String, u128)>) -> MatchedEvent {
         MatchedEvent {
             rule_name: "test_rule".to_string(),
             event_type: "test::type".to_string(),
@@ -74,7 +74,7 @@ mod tests {
         let field = "amount".to_string();
 
         // Prime the counter to a known non-zero value.
-        sink.try_deliver(&matched(vec![(field.clone(), 100u128)], &instance));
+        sink.try_deliver(&matched(vec![(field.clone(), 100u128)]));
         let before = EVENT_FIELD_VALUE_TOTAL
             .with_label_values(&["test_rule", "amount", &instance])
             .get();
@@ -83,7 +83,7 @@ mod tests {
         // Deliver a value above u64::MAX. The value counter must NOT change;
         // the overflow counter must increment by 1.
         let huge = u128::from(u64::MAX) + 1;
-        sink.try_deliver(&matched(vec![(field.clone(), huge)], &instance));
+        sink.try_deliver(&matched(vec![(field.clone(), huge)]));
 
         let after = EVENT_FIELD_VALUE_TOTAL
             .with_label_values(&["test_rule", "amount", &instance])
@@ -107,7 +107,7 @@ mod tests {
             chrono::Utc::now().timestamp_nanos_opt().unwrap()
         );
         let sink = PrometheusSink::new(instance.clone());
-        sink.try_deliver(&matched(vec![("amount".to_string(), 42u128)], &instance));
+        sink.try_deliver(&matched(vec![("amount".to_string(), 42u128)]));
         let value = EVENT_FIELD_VALUE_TOTAL
             .with_label_values(&["test_rule", "amount", &instance])
             .get();

--- a/processor/src/config/app_config.rs
+++ b/processor/src/config/app_config.rs
@@ -1,0 +1,188 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use super::{db_config::DbConfig, indexer_processor_config::IndexerProcessorConfig};
+use crate::alerting::app_config::AlertingAppConfig;
+use anyhow::Result;
+use aptos_indexer_processor_sdk::server_framework::{ProgressHealthConfig, RunnableConfig};
+use serde::{Deserialize, Serialize};
+
+/// Top-level YAML root. Distinguishes the two classes of application
+/// this binary can run: indexing processors (`Processor`) and the
+/// signal-generation alerting application (`Alerting`).
+///
+/// Untagged: serde picks the variant by which top-level field is
+/// present (`processor_config:` vs `alerting_config:`). Existing
+/// indexer YAMLs parse unchanged.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum AppConfig {
+    Processor(IndexerProcessorConfig),
+    Alerting(AlertingAppConfig),
+}
+
+impl AppConfig {
+    /// Returns the postgres `DbConfig` only when the active variant
+    /// participates in checkpoint-based progress tracking. Alerting
+    /// has no `processor_status` row and must not be subjected to
+    /// progress-based health checks.
+    pub fn progress_health_db_config(&self) -> Option<&DbConfig> {
+        match self {
+            AppConfig::Processor(c) => match &c.db_config {
+                DbConfig::NoneConfig => None,
+                other => Some(other),
+            },
+            AppConfig::Alerting(_) => None,
+        }
+    }
+
+    pub fn progress_health_config(&self) -> Option<&ProgressHealthConfig> {
+        match self {
+            AppConfig::Processor(c) => c.progress_health_config.as_ref(),
+            // Alerting writes no progress checkpoint, so progress-based
+            // health checking would be meaningless.
+            AppConfig::Alerting(_) => None,
+        }
+    }
+
+    pub fn processor_name(&self) -> String {
+        match self {
+            AppConfig::Processor(c) => c.processor_config.name().to_string(),
+            AppConfig::Alerting(_) => "alerting".to_string(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl RunnableConfig for AppConfig {
+    async fn run(&self) -> Result<()> {
+        match self {
+            AppConfig::Processor(c) => c.run().await,
+            AppConfig::Alerting(c) => c.run().await,
+        }
+    }
+
+    fn get_server_name(&self) -> String {
+        match self {
+            AppConfig::Processor(c) => c.get_server_name(),
+            AppConfig::Alerting(c) => c.get_server_name(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn processor_value() -> serde_json::Value {
+        json!({
+            "processor_config": {
+                "type": "default_processor",
+                "per_table_chunk_sizes": {},
+                "channel_size": 100u64,
+                "tables_to_write": [],
+            },
+            "transaction_stream_config": {
+                "indexer_grpc_data_service_address": "https://test.example/",
+                "auth_token": "test",
+                "request_name_header": "test",
+            },
+            "db_config": {
+                "type": "postgres_config",
+                "connection_string": "postgres://test",
+            },
+            "processor_mode": {
+                "type": "default",
+                "initial_starting_version": 0,
+            },
+        })
+    }
+
+    fn alerting_value() -> serde_json::Value {
+        json!({
+            "alerting_config": {
+                "chain_id": 1,
+                "rules": [{
+                    "name": "example",
+                    "module_address": "0x1",
+                    "module_name": "coin",
+                    "event_name": "WithdrawEvent",
+                    "sinks": ["prometheus"],
+                }],
+                "instance_label": "live",
+            },
+            "transaction_stream_config": {
+                "indexer_grpc_data_service_address": "https://test.example/",
+                "auth_token": "test",
+                "request_name_header": "test",
+            },
+        })
+    }
+
+    #[test]
+    fn processor_config_parses_as_processor_variant() {
+        let parsed: AppConfig = serde_json::from_value(processor_value()).expect("processor");
+        assert!(matches!(parsed, AppConfig::Processor(_)));
+    }
+
+    #[test]
+    fn alerting_config_parses_as_alerting_variant() {
+        let parsed: AppConfig = serde_json::from_value(alerting_value()).expect("alerting");
+        let AppConfig::Alerting(c) = parsed else {
+            panic!("expected Alerting variant");
+        };
+        assert_eq!(c.alerting_config.rules.len(), 1);
+        assert_eq!(c.alerting_config.chain_id, 1);
+        assert_eq!(c.alerting_config.instance_label, "live");
+    }
+
+    #[test]
+    fn alerting_config_uses_default_instance_label_when_unset() {
+        let parsed: AppConfig = serde_json::from_value(json!({
+            "alerting_config": {
+                "chain_id": 1,
+                "rules": [{
+                    "name": "example",
+                    "module_address": "0x1",
+                    "module_name": "coin",
+                    "event_name": "WithdrawEvent",
+                }],
+            },
+            "transaction_stream_config": {
+                "indexer_grpc_data_service_address": "https://test.example/",
+                "auth_token": "test",
+                "request_name_header": "test",
+            },
+        }))
+        .expect("alerting");
+        let AppConfig::Alerting(c) = parsed else {
+            panic!("expected Alerting variant");
+        };
+        assert_eq!(c.alerting_config.instance_label, "live");
+        assert_eq!(c.alerting_config.from_version, None);
+        assert_eq!(c.alerting_config.to_version, None);
+    }
+
+    #[test]
+    fn alerting_config_rejects_missing_chain_id() {
+        // chain_id is required — operator opt-out is intentionally
+        // unsupported so alerts are never silently bound to the wrong chain.
+        let result: Result<AppConfig, _> = serde_json::from_value(json!({
+            "alerting_config": {
+                "rules": [{
+                    "name": "example",
+                    "module_address": "0x1",
+                    "module_name": "coin",
+                    "event_name": "WithdrawEvent",
+                }],
+            },
+            "transaction_stream_config": {
+                "indexer_grpc_data_service_address": "https://test.example/",
+                "auth_token": "test",
+                "request_name_header": "test",
+            },
+        }));
+        assert!(result.is_err(), "expected parse failure for missing chain_id");
+    }
+}

--- a/processor/src/config/app_config.rs
+++ b/processor/src/config/app_config.rs
@@ -7,13 +7,8 @@ use anyhow::Result;
 use aptos_indexer_processor_sdk::server_framework::{ProgressHealthConfig, RunnableConfig};
 use serde::{Deserialize, Serialize};
 
-/// Top-level YAML root. Distinguishes the two classes of application
-/// this binary can run: indexing processors (`Processor`) and the
-/// signal-generation alerting application (`Alerting`).
-///
-/// Untagged: serde picks the variant by which top-level field is
-/// present (`processor_config:` vs `alerting_config:`). Existing
-/// indexer YAMLs parse unchanged.
+/// Top-level YAML root. Serde picks the variant by which field is
+/// present (`processor_config:` vs `alerting_config:`).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum AppConfig {
@@ -22,10 +17,8 @@ pub enum AppConfig {
 }
 
 impl AppConfig {
-    /// Returns the postgres `DbConfig` only when the active variant
-    /// participates in checkpoint-based progress tracking. Alerting
-    /// has no `processor_status` row and must not be subjected to
-    /// progress-based health checks.
+    /// `None` for variants that don't participate in checkpoint-based
+    /// progress tracking (Alerting has no `processor_status` row).
     pub fn progress_health_db_config(&self) -> Option<&DbConfig> {
         match self {
             AppConfig::Processor(c) => match &c.db_config {
@@ -39,8 +32,6 @@ impl AppConfig {
     pub fn progress_health_config(&self) -> Option<&ProgressHealthConfig> {
         match self {
             AppConfig::Processor(c) => c.progress_health_config.as_ref(),
-            // Alerting writes no progress checkpoint, so progress-based
-            // health checking would be meaningless.
             AppConfig::Alerting(_) => None,
         }
     }
@@ -73,21 +64,33 @@ impl RunnableConfig for AppConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
+    use serde_json::{Value, json};
 
-    fn processor_value() -> serde_json::Value {
+    fn stream_config() -> Value {
         json!({
+            "indexer_grpc_data_service_address": "https://test.example/",
+            "auth_token": "test",
+            "request_name_header": "test",
+        })
+    }
+
+    fn alerting_value(alerting: Value) -> Value {
+        json!({
+            "alerting_config": alerting,
+            "transaction_stream_config": stream_config(),
+        })
+    }
+
+    #[test]
+    fn processor_config_parses_as_processor_variant() {
+        let parsed: AppConfig = serde_json::from_value(json!({
             "processor_config": {
                 "type": "default_processor",
                 "per_table_chunk_sizes": {},
                 "channel_size": 100u64,
                 "tables_to_write": [],
             },
-            "transaction_stream_config": {
-                "indexer_grpc_data_service_address": "https://test.example/",
-                "auth_token": "test",
-                "request_name_header": "test",
-            },
+            "transaction_stream_config": stream_config(),
             "db_config": {
                 "type": "postgres_config",
                 "connection_string": "postgres://test",
@@ -96,39 +99,25 @@ mod tests {
                 "type": "default",
                 "initial_starting_version": 0,
             },
-        })
-    }
-
-    fn alerting_value() -> serde_json::Value {
-        json!({
-            "alerting_config": {
-                "chain_id": 1,
-                "rules": [{
-                    "name": "example",
-                    "module_address": "0x1",
-                    "module_name": "coin",
-                    "event_name": "WithdrawEvent",
-                    "sinks": ["prometheus"],
-                }],
-                "instance_label": "live",
-            },
-            "transaction_stream_config": {
-                "indexer_grpc_data_service_address": "https://test.example/",
-                "auth_token": "test",
-                "request_name_header": "test",
-            },
-        })
-    }
-
-    #[test]
-    fn processor_config_parses_as_processor_variant() {
-        let parsed: AppConfig = serde_json::from_value(processor_value()).expect("processor");
+        }))
+        .expect("processor");
         assert!(matches!(parsed, AppConfig::Processor(_)));
     }
 
     #[test]
     fn alerting_config_parses_as_alerting_variant() {
-        let parsed: AppConfig = serde_json::from_value(alerting_value()).expect("alerting");
+        let parsed: AppConfig = serde_json::from_value(alerting_value(json!({
+            "chain_id": 1,
+            "rules": [{
+                "name": "example",
+                "module_address": "0x1",
+                "module_name": "coin",
+                "event_name": "WithdrawEvent",
+                "sinks": ["prometheus"],
+            }],
+            "instance_label": "live",
+        })))
+        .expect("alerting");
         let AppConfig::Alerting(c) = parsed else {
             panic!("expected Alerting variant");
         };
@@ -139,22 +128,15 @@ mod tests {
 
     #[test]
     fn alerting_config_uses_default_instance_label_when_unset() {
-        let parsed: AppConfig = serde_json::from_value(json!({
-            "alerting_config": {
-                "chain_id": 1,
-                "rules": [{
-                    "name": "example",
-                    "module_address": "0x1",
-                    "module_name": "coin",
-                    "event_name": "WithdrawEvent",
-                }],
-            },
-            "transaction_stream_config": {
-                "indexer_grpc_data_service_address": "https://test.example/",
-                "auth_token": "test",
-                "request_name_header": "test",
-            },
-        }))
+        let parsed: AppConfig = serde_json::from_value(alerting_value(json!({
+            "chain_id": 1,
+            "rules": [{
+                "name": "example",
+                "module_address": "0x1",
+                "module_name": "coin",
+                "event_name": "WithdrawEvent",
+            }],
+        })))
         .expect("alerting");
         let AppConfig::Alerting(c) = parsed else {
             panic!("expected Alerting variant");
@@ -166,26 +148,14 @@ mod tests {
 
     #[test]
     fn alerting_config_rejects_missing_chain_id() {
-        // chain_id is required — operator opt-out is intentionally
-        // unsupported so alerts are never silently bound to the wrong chain.
-        let result: Result<AppConfig, _> = serde_json::from_value(json!({
-            "alerting_config": {
-                "rules": [{
-                    "name": "example",
-                    "module_address": "0x1",
-                    "module_name": "coin",
-                    "event_name": "WithdrawEvent",
-                }],
-            },
-            "transaction_stream_config": {
-                "indexer_grpc_data_service_address": "https://test.example/",
-                "auth_token": "test",
-                "request_name_header": "test",
-            },
-        }));
-        assert!(
-            result.is_err(),
-            "expected parse failure for missing chain_id"
-        );
+        let result: Result<AppConfig, _> = serde_json::from_value(alerting_value(json!({
+            "rules": [{
+                "name": "example",
+                "module_address": "0x1",
+                "module_name": "coin",
+                "event_name": "WithdrawEvent",
+            }],
+        })));
+        assert!(result.is_err());
     }
 }

--- a/processor/src/config/app_config.rs
+++ b/processor/src/config/app_config.rs
@@ -183,6 +183,9 @@ mod tests {
                 "request_name_header": "test",
             },
         }));
-        assert!(result.is_err(), "expected parse failure for missing chain_id");
+        assert!(
+            result.is_err(),
+            "expected parse failure for missing chain_id"
+        );
     }
 }

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -12,6 +12,7 @@ extern crate canonical_json;
 extern crate parquet;
 extern crate parquet_derive;
 
+pub mod alerting;
 pub mod config;
 pub mod db;
 pub mod parquet_processors;

--- a/processor/src/main.rs
+++ b/processor/src/main.rs
@@ -10,7 +10,7 @@ use aptos_indexer_processor_sdk::{
     },
 };
 use clap::Parser;
-use processor::config::{db_config::DbConfig, indexer_processor_config::IndexerProcessorConfig};
+use processor::config::{app_config::AppConfig, db_config::DbConfig};
 use std::sync::Arc;
 
 #[cfg(unix)]
@@ -35,18 +35,20 @@ fn main() -> Result<()> {
             setup_logging();
             setup_panic_handler();
 
-            let config = load::<GenericConfig<IndexerProcessorConfig>>(&args.config_path)?;
+            let config = load::<GenericConfig<AppConfig>>(&args.config_path)?;
             let handle = tokio::runtime::Handle::current();
 
             let mut health_checks: Vec<Arc<dyn HealthCheck>> = vec![];
-            if let Some(ref progress_config) = config.server_config.progress_health_config {
-                // Skip DB-based health checking for processors that don't use a database.
-                if !matches!(config.server_config.db_config, DbConfig::NoneConfig) {
-                    let connection_string = config.server_config.db_config.connection_string();
+            if let Some(progress_config) = config.server_config.progress_health_config() {
+                // Skip DB-based health checking for apps that don't write a processor_status row.
+                if let Some(db_config) = config.server_config.progress_health_db_config()
+                    && !matches!(db_config, DbConfig::NoneConfig)
+                {
+                    let connection_string = db_config.connection_string();
                     let health_db_pool = new_db_pool(connection_string, Some(2))
                         .await
                         .context("Failed to create health check DB pool")?;
-                    let processor_name = config.server_config.processor_config.name().to_string();
+                    let processor_name = config.server_config.processor_name();
                     let status_provider =
                         PostgresProgressStatusProvider::new(processor_name.clone(), health_db_pool);
                     let progress_checker = ProgressHealthChecker::new(

--- a/processor/src/main.rs
+++ b/processor/src/main.rs
@@ -10,7 +10,7 @@ use aptos_indexer_processor_sdk::{
     },
 };
 use clap::Parser;
-use processor::config::{app_config::AppConfig, db_config::DbConfig};
+use processor::config::app_config::AppConfig;
 use std::sync::Arc;
 
 #[cfg(unix)]
@@ -40,10 +40,10 @@ fn main() -> Result<()> {
 
             let mut health_checks: Vec<Arc<dyn HealthCheck>> = vec![];
             if let Some(progress_config) = config.server_config.progress_health_config() {
-                // Skip DB-based health checking for apps that don't write a processor_status row.
-                if let Some(db_config) = config.server_config.progress_health_db_config()
-                    && !matches!(db_config, DbConfig::NoneConfig)
-                {
+                // progress_health_db_config() already returns None for apps
+                // that don't write a processor_status row (alerting,
+                // NoneConfig), so a Some here is always a real DB config.
+                if let Some(db_config) = config.server_config.progress_health_db_config() {
                     let connection_string = db_config.connection_string();
                     let health_db_pool = new_db_pool(connection_string, Some(2))
                         .await

--- a/processor/src/processors/event_file/event_file_extractor.rs
+++ b/processor/src/processors/event_file/event_file_extractor.rs
@@ -57,7 +57,7 @@ impl EventFileExtractorStep {
 ///
 /// `event_name` is checked independently of `module_name` — you can filter by
 /// just address + event_name without specifying the module.
-fn event_matches_filter(event: &Event, filter: &SingleEventFilter) -> bool {
+pub fn event_matches_filter(event: &Event, filter: &SingleEventFilter) -> bool {
     let type_str = &event.type_str;
 
     if type_str.is_empty() {

--- a/processor/src/utils/counters.rs
+++ b/processor/src/utils/counters.rs
@@ -56,9 +56,7 @@ pub static PARQUET_BUFFER_SIZE_AFTER_UPLOAD: Lazy<IntGaugeVec> = Lazy::new(|| {
     .unwrap()
 });
 
-/// Total events matched by an alerting rule. The metric describes what is
-/// measured (event matches); what an operator does with these signals
-/// (page, dashboard, audit) is a downstream Grafana/incident.io concern.
+/// Total events matched by an alerting rule.
 pub static EVENT_MATCH_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "event_match_total",
@@ -68,8 +66,7 @@ pub static EVENT_MATCH_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
-/// Matched events dropped because their block timestamp is older than the
-/// configured `max_alert_age_secs`. Visible during catchup after downtime.
+/// Matched events dropped for being older than `max_alert_age_secs`.
 pub static EVENT_STALE_DROPPED_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "event_stale_dropped_total",
@@ -79,9 +76,8 @@ pub static EVENT_STALE_DROPPED_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
-/// Cumulative sum of a numeric payload field across matches. Use Grafana
-/// `increase()` over a window for time-windowed aggregations such as
-/// `SUM(withdraw_amount) over last 30m`.
+/// Cumulative sum of a numeric payload field across matches. Use
+/// `increase()` in Grafana for windowed aggregations.
 pub static EVENT_FIELD_VALUE_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "event_field_value_total",
@@ -91,9 +87,8 @@ pub static EVENT_FIELD_VALUE_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
-/// Count of failures to parse a configured numeric field. If non-zero a
-/// rule's `emit_field_values` config is mismatched with the on-chain
-/// payload shape.
+/// Count of failures to parse a configured numeric field — non-zero means
+/// `emit_field_values` is mismatched with the on-chain payload shape.
 pub static EVENT_FIELD_PARSE_ERRORS_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "event_field_parse_errors_total",
@@ -103,10 +98,8 @@ pub static EVENT_FIELD_PARSE_ERRORS_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
-/// Count of times a parsed `u128` field value exceeded `u64::MAX` and was
-/// saturated when added to `event_field_value_total`. A non-zero rate
-/// means the field-value counter is plateauing artificially and the
-/// rule's emit_field_values choice should be reconsidered.
+/// Count of field values saturated to `u64::MAX` when added to
+/// `event_field_value_total` — non-zero means that counter is plateauing.
 pub static EVENT_FIELD_VALUE_OVERFLOW_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "event_field_value_overflow_total",
@@ -116,13 +109,9 @@ pub static EVENT_FIELD_VALUE_OVERFLOW_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| 
     .unwrap()
 });
 
-/// Count of `gt/gte/lt/lte` condition evaluations that failed because the
-/// event's field value did not parse as `u128`. Config-side parse errors
-/// are caught at startup, so a non-zero rate here means the on-chain
-/// payload shape doesn't match what the rule assumed (e.g. the field is
-/// missing on this variant, or the field is a struct rather than a
-/// number). A silently-never-firing rule is the worst alerting failure
-/// mode — surface it.
+/// Numeric condition evals where the event-side value didn't parse as
+/// `u128` — config side is validated at startup, so non-zero means the
+/// on-chain payload shape doesn't match what the rule assumed.
 pub static EVENT_CONDITION_COMPARE_ERRORS_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "event_condition_compare_errors_total",
@@ -132,10 +121,9 @@ pub static EVENT_CONDITION_COMPARE_ERRORS_TOTAL: Lazy<IntCounterVec> = Lazy::new
     .unwrap()
 });
 
-/// Seconds between now() and the latest processed transaction's block
-/// timestamp. First-class signal: page when this exceeds threshold;
-/// aggregate alerts should AND against this < threshold to avoid firing
-/// on stale data.
+/// Seconds between now() and the latest processed block timestamp.
+/// First-class paging signal — aggregate alerts should AND against
+/// this < threshold to avoid firing on stale data.
 pub static EVENT_PIPELINE_LAG_SECONDS: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         "event_pipeline_lag_seconds",
@@ -145,13 +133,8 @@ pub static EVENT_PIPELINE_LAG_SECONDS: Lazy<IntGaugeVec> = Lazy::new(|| {
     .unwrap()
 });
 
-/// Dump current values of `event_match_total` for the given `instance`
-/// label. Called by the alerting processor at shutdown so replay runs
-/// have a definitive final count in stdout without needing to scrape
-/// `/metrics` mid-flight.
-///
-/// Lives here next to the counter declaration so the `prometheus::Collector`
-/// internals don't leak into the alerting module.
+/// Log current `event_match_total` series for `instance_label` at shutdown
+/// so replay runs have a final count in stdout without scraping `/metrics`.
 pub fn log_match_counter_summary(instance_label: &str) {
     for mf in EVENT_MATCH_TOTAL.collect() {
         for m in mf.get_metric() {
@@ -182,20 +165,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn log_match_counter_summary_does_not_panic_when_no_metrics() {
-        // Smoke test: the function must tolerate a label that has never
-        // been emitted (i.e. zero series under the filter) without panicking.
-        let unique = format!(
-            "test_no_data_{}",
-            chrono::Utc::now().timestamp_nanos_opt().unwrap()
-        );
-        log_match_counter_summary(&unique);
-    }
-
-    #[test]
     fn log_match_counter_summary_walks_recorded_series() {
-        // Bump a series under a distinct instance label so this test
-        // doesn't race against other tests' counter values.
         let unique = format!(
             "test_walk_{}",
             chrono::Utc::now().timestamp_nanos_opt().unwrap()
@@ -203,9 +173,6 @@ mod tests {
         EVENT_MATCH_TOTAL
             .with_label_values(&["test_rule", "test::type", &unique])
             .inc();
-        // No structured way to assert on tracing output here without
-        // wiring a tracing subscriber — the value is the panic-free walk
-        // plus visibility through `cargo test -- --nocapture` if needed.
         log_match_counter_summary(&unique);
     }
 }

--- a/processor/src/utils/counters.rs
+++ b/processor/src/utils/counters.rs
@@ -2,7 +2,10 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use once_cell::sync::Lazy;
-use prometheus::{IntCounterVec, IntGaugeVec, register_int_counter_vec, register_int_gauge_vec};
+use prometheus::{
+    IntCounterVec, IntGaugeVec, core::Collector, register_int_counter_vec, register_int_gauge_vec,
+};
+use tracing::info;
 
 /// Processor unknown type count.
 pub static PROCESSOR_UNKNOWN_TYPE_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
@@ -52,3 +55,154 @@ pub static PARQUET_BUFFER_SIZE_AFTER_UPLOAD: Lazy<IntGaugeVec> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+/// Total events matched by an alerting rule. The metric describes what is
+/// measured (event matches); what an operator does with these signals
+/// (page, dashboard, audit) is a downstream Grafana/incident.io concern.
+pub static EVENT_MATCH_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "event_match_total",
+        "Count of on-chain events that matched an alerting rule",
+        &["rule", "event_type", "instance"]
+    )
+    .unwrap()
+});
+
+/// Matched events dropped because their block timestamp is older than the
+/// configured `max_alert_age_secs`. Visible during catchup after downtime.
+pub static EVENT_STALE_DROPPED_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "event_stale_dropped_total",
+        "Count of matched events dropped due to staleness",
+        &["rule", "instance"]
+    )
+    .unwrap()
+});
+
+/// Cumulative sum of a numeric payload field across matches. Use Grafana
+/// `increase()` over a window for time-windowed aggregations such as
+/// `SUM(withdraw_amount) over last 30m`.
+pub static EVENT_FIELD_VALUE_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "event_field_value_total",
+        "Cumulative sum of a configured numeric payload field across matched events",
+        &["rule", "field", "instance"]
+    )
+    .unwrap()
+});
+
+/// Count of failures to parse a configured numeric field. If non-zero a
+/// rule's `emit_field_values` config is mismatched with the on-chain
+/// payload shape.
+pub static EVENT_FIELD_PARSE_ERRORS_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "event_field_parse_errors_total",
+        "Count of failures to parse a numeric payload field configured via emit_field_values",
+        &["rule", "field", "instance"]
+    )
+    .unwrap()
+});
+
+/// Count of times a parsed `u128` field value exceeded `u64::MAX` and was
+/// saturated when added to `event_field_value_total`. A non-zero rate
+/// means the field-value counter is plateauing artificially and the
+/// rule's emit_field_values choice should be reconsidered.
+pub static EVENT_FIELD_VALUE_OVERFLOW_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "event_field_value_overflow_total",
+        "Count of matched events whose numeric field value overflowed u64 and was saturated",
+        &["rule", "field", "instance"]
+    )
+    .unwrap()
+});
+
+/// Count of `gt/gte/lt/lte` condition evaluations that failed because the
+/// event's field value did not parse as `u128`. Config-side parse errors
+/// are caught at startup, so a non-zero rate here means the on-chain
+/// payload shape doesn't match what the rule assumed (e.g. the field is
+/// missing on this variant, or the field is a struct rather than a
+/// number). A silently-never-firing rule is the worst alerting failure
+/// mode — surface it.
+pub static EVENT_CONDITION_COMPARE_ERRORS_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "event_condition_compare_errors_total",
+        "Count of numeric condition evaluations whose event-side value did not parse as u128",
+        &["rule", "path", "instance"]
+    )
+    .unwrap()
+});
+
+/// Seconds between now() and the latest processed transaction's block
+/// timestamp. First-class signal: page when this exceeds threshold;
+/// aggregate alerts should AND against this < threshold to avoid firing
+/// on stale data.
+pub static EVENT_PIPELINE_LAG_SECONDS: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "event_pipeline_lag_seconds",
+        "Seconds between now() and the latest processed transaction's block timestamp",
+        &["instance"]
+    )
+    .unwrap()
+});
+
+/// Dump current values of `event_match_total` for the given `instance`
+/// label. Called by the alerting processor at shutdown so replay runs
+/// have a definitive final count in stdout without needing to scrape
+/// `/metrics` mid-flight.
+///
+/// Lives here next to the counter declaration so the `prometheus::Collector`
+/// internals don't leak into the alerting module.
+pub fn log_match_counter_summary(instance_label: &str) {
+    for mf in EVENT_MATCH_TOTAL.collect() {
+        for m in mf.get_metric() {
+            let mut rule = "";
+            let mut event_type = "";
+            let mut instance = "";
+            for label in m.get_label() {
+                match label.get_name() {
+                    "rule" => rule = label.get_value(),
+                    "event_type" => event_type = label.get_value(),
+                    "instance" => instance = label.get_value(),
+                    _ => {},
+                }
+            }
+            let count = m.get_counter().get_value();
+            if instance == instance_label && count > 0.0 {
+                info!(
+                    instance,
+                    rule,
+                    event_type,
+                    count,
+                    "Final match-counter value at shutdown"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn log_match_counter_summary_does_not_panic_when_no_metrics() {
+        // Smoke test: the function must tolerate a label that has never
+        // been emitted (i.e. zero series under the filter) without panicking.
+        let unique = format!("test_no_data_{}", chrono::Utc::now().timestamp_nanos_opt().unwrap());
+        log_match_counter_summary(&unique);
+    }
+
+    #[test]
+    fn log_match_counter_summary_walks_recorded_series() {
+        // Bump a series under a distinct instance label so this test
+        // doesn't race against other tests' counter values.
+        let unique = format!("test_walk_{}", chrono::Utc::now().timestamp_nanos_opt().unwrap());
+        EVENT_MATCH_TOTAL
+            .with_label_values(&["test_rule", "test::type", &unique])
+            .inc();
+        // No structured way to assert on tracing output here without
+        // wiring a tracing subscriber — the value is the panic-free walk
+        // plus visibility through `cargo test -- --nocapture` if needed.
+        log_match_counter_summary(&unique);
+    }
+}

--- a/processor/src/utils/counters.rs
+++ b/processor/src/utils/counters.rs
@@ -170,10 +170,7 @@ pub fn log_match_counter_summary(instance_label: &str) {
             if instance == instance_label && count > 0.0 {
                 info!(
                     instance,
-                    rule,
-                    event_type,
-                    count,
-                    "Final match-counter value at shutdown"
+                    rule, event_type, count, "Final match-counter value at shutdown"
                 );
             }
         }
@@ -188,7 +185,10 @@ mod tests {
     fn log_match_counter_summary_does_not_panic_when_no_metrics() {
         // Smoke test: the function must tolerate a label that has never
         // been emitted (i.e. zero series under the filter) without panicking.
-        let unique = format!("test_no_data_{}", chrono::Utc::now().timestamp_nanos_opt().unwrap());
+        let unique = format!(
+            "test_no_data_{}",
+            chrono::Utc::now().timestamp_nanos_opt().unwrap()
+        );
         log_match_counter_summary(&unique);
     }
 
@@ -196,7 +196,10 @@ mod tests {
     fn log_match_counter_summary_walks_recorded_series() {
         // Bump a series under a distinct instance label so this test
         // doesn't race against other tests' counter values.
-        let unique = format!("test_walk_{}", chrono::Utc::now().timestamp_nanos_opt().unwrap());
+        let unique = format!(
+            "test_walk_{}",
+            chrono::Utc::now().timestamp_nanos_opt().unwrap()
+        );
         EVENT_MATCH_TOTAL
             .with_label_values(&["test_rule", "test::type", &unique])
             .inc();


### PR DESCRIPTION
## Summary
Adds a new "alerting" processor: a peer to the indexer processors that consumes the Aptos transaction stream and emits Prometheus metrics for rule-matched Move events. Designed for low-latency operational alerting via Grafana / incident.io, not for data storage.

   - **Live-first by default.** Starts at chain tip, no checkpoint resume, no `VersionTrackerStep`. `event_pipeline_lag_seconds{instance}` is a first-class paging signal so a degraded pipeline pages distinctly from real event alerts.
   - **Bounded replay** via `from_version`/`to_version` for after-the-fact "what did we miss" runs. Replay deploys use a distinct `instance_label` so metrics don't blend with live signal.  Also useful for testing.
   - **Rule engine** supports event-type filters plus dot-path JSON conditions (`eq`/`ne`/`gt`/`gte`/`lt`/`lte`) on Move enum payloads (`__variant__` discriminators and arbitrary nesting depth).
   - **AppConfig umbrella** (`#[serde(untagged)]`) splits alerting and indexer-processor configs at the YAML root. Existing indexer YAMLs parse unchanged; alerting YAMLs don't need `processor_mode` or `db_config`.
   - Ships only the built-in **prometheus sink**. 

   Grafana does windowed aggregation via `event_field_value_total` counters (e.g. `sum(increase(...{field="X"}[30m])) > T`) — no in-process
   accumulators.

   ## Test plan

   - [x] Unit: 27 alerting tests cover the matcher (nested enums, `__variant__`, numeric coercion, ComparisonNonNumeric vs Fail), extractor,
   dispatcher lag gauge, validate(), AppConfig round-trip parsing, counter shutdown summary.
   - [x] Full lib test suite: 86 tests pass (`cargo test -p processor --lib`).
   - [x] End-to-end replay validated against two real mainnet txns: `PairedCollateralWithdrawalEvent` (1 match) and `ACKEvent` with nested-enum match
   on `ack_phase.__variant__` (4 / 2 / 2 across three rules in the bounded window).
   - [x] Live mode validated against mainnet — `starting_version: None` lands at chain tip, `event_pipeline_lag_seconds` reads single-digit seconds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New operational path on the live gRPC stream with config-driven rules and paging-oriented metrics; mistakes in rules or replay settings could mis-signal, but there is no persistence or auth change in this PR.
> 
> **Overview**
> Introduces a new **alerting** application that reads the Aptos transaction gRPC stream, matches Move events against YAML rules, and emits **Prometheus** metrics (no DB/checkpoints). Wiring uses an untagged **`AppConfig`** so existing indexer YAML is unchanged while alerting configs use `alerting_config` + `transaction_stream_config` only.
> 
> The pipeline is **stream → extractor → dispatcher**: rules compile to a server-side filter (`success AND` OR of event tags); the extractor applies shared JSON payload conditions (`eq`/`ne`/`gt`/…) and optional `emit_field_values`; the dispatcher enforces **`max_alert_age_secs`**, updates **`event_pipeline_lag_seconds`**, and delivers to sinks (v1: built-in `prometheus`). **Live** mode starts at tip; **replay** uses `from_version`/`to_version` and a distinct **`instance_label`**. Startup validates rules (numeric ops, sinks, duplicate names), checks **chain_id** against the stream, and canonicalizes addresses to stay aligned with the filter compiler.
> 
> **`main`** loads `GenericConfig<AppConfig>` and skips DB progress health for alerting. **`event_matches_filter`** is exported for reuse. New metrics and an example **`example-config-alerting.yaml`** document operational use; `.gitignore` ignores local token configs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f67ce026a643436ff78df068f988e97509afb41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->