### PR TITLE
Add event file storage trait dispatch

### DIFF
--- a/integration-tests/src/sdk_tests/event_file_processor_tests.rs
+++ b/integration-tests/src/sdk_tests/event_file_processor_tests.rs
@@ -35,7 +35,7 @@ use std::{path::PathBuf, sync::Arc};
 async fn crash_after_file_write_before_metadata() {
     let scenario = FailScenario::setup();
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: Arc<LocalFileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
     let mut config = test_config();
     config.max_seconds_between_flushes = 0;
 
@@ -78,7 +78,7 @@ async fn crash_after_file_write_before_metadata() {
 async fn crash_after_folder_metadata_before_root() {
     let scenario = FailScenario::setup();
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: Arc<LocalFileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
     let mut config = test_config();
     config.max_seconds_between_flushes = 0;
 
@@ -140,7 +140,7 @@ async fn crash_after_folder_metadata_before_root() {
 async fn crash_with_flushed_and_buffered_events() {
     let scenario = FailScenario::setup();
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: Arc<LocalFileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
     let mut config = test_config();
     config.max_txns_per_folder = 3;
 
@@ -193,7 +193,7 @@ async fn crash_with_flushed_and_buffered_events() {
 async fn repeated_crash_recovery_no_drift() {
     let scenario = FailScenario::setup();
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: Arc<LocalFileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
     let mut config = test_config();
     config.max_txns_per_folder = 1000;
     // With max_seconds_between_flushes=0 the time trigger fires on every new

--- a/processor/src/processors/event_file/event_file_processor.rs
+++ b/processor/src/processors/event_file/event_file_processor.rs
@@ -6,7 +6,7 @@ use super::{
     event_file_extractor::EventFileExtractorStep,
     event_file_writer::EventFileWriterStep,
     metadata::{InternalFolderState, METADATA_FILE_NAME, RootMetadata},
-    storage::{FileStore, GcsFileStore},
+    storage::{EventFileStorage, FileStore, GcsFileStore},
 };
 use crate::config::{
     indexer_processor_config::IndexerProcessorConfig, processor_config::ProcessorConfig,
@@ -45,7 +45,7 @@ pub struct RecoveredState {
 /// Exposed as a free function so crash-recovery tests can call it directly
 /// without constructing a full `EventFileProcessor`.
 pub async fn recover_state(
-    store: &Arc<dyn FileStore>,
+    store: &impl FileStore,
     config: &EventFileProcessorConfig,
     default_starting_version: u64,
 ) -> Result<RecoveredState> {
@@ -258,7 +258,7 @@ impl EventFileProcessor {
     /// folder state, and chain_id. If no metadata exists yet this is a fresh
     /// start and we return defaults without writing anything — the root metadata
     /// is only written once we know the chain_id (from the gRPC stream).
-    async fn recover_or_initialize(&self, store: &Arc<dyn FileStore>) -> Result<RecoveredState> {
+    async fn recover_or_initialize(&self, store: &impl FileStore) -> Result<RecoveredState> {
         recover_state(
             store,
             &self.event_file_config,
@@ -275,7 +275,7 @@ impl ProcessorTrait for EventFileProcessor {
     }
 
     async fn run_processor(&self) -> Result<()> {
-        let store: Arc<dyn FileStore> = Arc::new(
+        let store = Arc::new(EventFileStorage::from(
             GcsFileStore::new(
                 self.event_file_config.bucket_name.clone(),
                 self.event_file_config.bucket_root.clone(),
@@ -284,7 +284,7 @@ impl ProcessorTrait for EventFileProcessor {
                     .clone(),
             )
             .await?,
-        );
+        ));
 
         let recovered_state = self.recover_or_initialize(&store).await?;
 

--- a/processor/src/processors/event_file/event_file_writer.rs
+++ b/processor/src/processors/event_file/event_file_writer.rs
@@ -18,7 +18,7 @@ use aptos_indexer_processor_sdk::{
 };
 use async_trait::async_trait;
 use prost::Message;
-use std::{path::PathBuf, sync::Arc};
+use std::path::PathBuf;
 use tokio::time::Instant;
 use tracing::info;
 
@@ -48,8 +48,8 @@ impl std::fmt::Display for FlushReason {
 // let it be cached indefinitely because it will never change.
 const METADATA_CACHE_CONTROL: &str = "no-store";
 
-pub struct EventFileWriterStep {
-    store: Arc<dyn FileStore>,
+pub struct EventFileWriterStep<S> {
+    store: S,
     config: EventFileProcessorConfig,
     file_extension: &'static str,
     chain_id: u64,
@@ -95,9 +95,12 @@ pub struct EventFileWriterStep {
     last_root_metadata_update: Instant,
 }
 
-impl EventFileWriterStep {
+impl<S> EventFileWriterStep<S>
+where
+    S: FileStore,
+{
     pub fn new(
-        store: Arc<dyn FileStore>,
+        store: S,
         config: EventFileProcessorConfig,
         chain_id: u64,
         initial_starting_version: u64,
@@ -333,7 +336,10 @@ impl EventFileWriterStep {
 }
 
 #[async_trait]
-impl Processable for EventFileWriterStep {
+impl<S> Processable for EventFileWriterStep<S>
+where
+    S: FileStore + 'static,
+{
     type Input = Vec<EventWithContext>;
     type Output = ();
     type RunType = AsyncRunType;
@@ -423,9 +429,12 @@ impl Processable for EventFileWriterStep {
     }
 }
 
-impl AsyncStep for EventFileWriterStep {}
+impl<S> AsyncStep for EventFileWriterStep<S> where S: FileStore + 'static {}
 
-impl NamedStep for EventFileWriterStep {
+impl<S> NamedStep for EventFileWriterStep<S>
+where
+    S: FileStore,
+{
     fn name(&self) -> String {
         "EventFileWriterStep".to_string()
     }

--- a/processor/src/processors/event_file/storage.rs
+++ b/processor/src/processors/event_file/storage.rs
@@ -4,6 +4,7 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
+use enum_dispatch::enum_dispatch;
 use google_cloud_storage::{
     client::{Client as GCSClient, ClientConfig as GcsClientConfig},
     http::{
@@ -28,8 +29,9 @@ const GOOGLE_APPLICATION_CREDENTIALS: &str = "GOOGLE_APPLICATION_CREDENTIALS";
 const MAX_RETRIES: usize = 3;
 const INITIAL_RETRY_DELAY: Duration = Duration::from_millis(500);
 
-/// Abstraction over GCS / local filesystem for writing and reading files.
+/// Abstraction over storage backends for writing and reading event files.
 #[async_trait]
+#[enum_dispatch]
 pub trait FileStore: Send + Sync {
     /// Write `data` to `path`, optionally setting Cache-Control metadata on the
     /// object. When `cache_control` is `None` the store's default applies (for
@@ -46,10 +48,18 @@ pub trait FileStore: Send + Sync {
     fn max_update_frequency(&self) -> Duration;
 }
 
+/// Storage backends available to the event file processor.
+#[derive(Clone)]
+#[enum_dispatch(FileStore)]
+pub enum EventFileStorage {
+    Gcs(GcsFileStore),
+}
+
 // ---------------------------------------------------------------------------
 // GCS implementation
 // ---------------------------------------------------------------------------
 
+#[derive(Clone)]
 pub struct GcsFileStore {
     client: Arc<GCSClient>,
     bucket_name: String,
@@ -176,10 +186,34 @@ impl FileStore for GcsFileStore {
     }
 }
 
+#[async_trait]
+impl<T> FileStore for Arc<T>
+where
+    T: FileStore + ?Sized,
+{
+    async fn save_file(
+        &self,
+        path: PathBuf,
+        data: Vec<u8>,
+        cache_control: Option<&str>,
+    ) -> Result<()> {
+        (**self).save_file(path, data, cache_control).await
+    }
+
+    async fn get_file(&self, path: PathBuf) -> Result<Option<Vec<u8>>> {
+        (**self).get_file(path).await
+    }
+
+    fn max_update_frequency(&self) -> Duration {
+        (**self).max_update_frequency()
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Local filesystem implementation (for testing / development)
 // ---------------------------------------------------------------------------
 
+#[derive(Clone)]
 pub struct LocalFileStore {
     root: PathBuf,
 }

--- a/processor/src/processors/event_file/test_utils.rs
+++ b/processor/src/processors/event_file/test_utils.rs
@@ -19,7 +19,6 @@ use aptos_indexer_processor_sdk::{
     traits::Processable,
     types::transaction_context::{TransactionContext, TransactionMetadata},
 };
-use std::sync::Arc;
 
 pub fn test_config() -> EventFileProcessorConfig {
     EventFileProcessorConfig {
@@ -104,7 +103,7 @@ pub fn make_batch(
 }
 
 pub async fn do_recovery(
-    store: &Arc<dyn FileStore>,
+    store: &impl FileStore,
     config: &EventFileProcessorConfig,
 ) -> RecoveredState {
     recover_state(store, config, 0).await.unwrap()
@@ -112,8 +111,8 @@ pub async fn do_recovery(
 
 /// Process events with batch range derived from the events themselves.
 /// Suitable for most tests that don't care about the scanned range.
-pub async fn process_batch(
-    writer: &mut EventFileWriterStep,
+pub async fn process_batch<S: FileStore>(
+    writer: &mut EventFileWriterStep<S>,
     events: Vec<EventWithContext>,
 ) -> anyhow::Result<()> {
     let start = events.first().map_or(0, |e| e.version);
@@ -124,8 +123,8 @@ pub async fn process_batch(
 /// Process events with an explicit scanned range (`start_version..=end_version`,
 /// both inclusive). Use when the test needs the batch to represent a wider scan
 /// than just the matching events (e.g. to test `processed_version` semantics).
-pub async fn process_batch_with_range(
-    writer: &mut EventFileWriterStep,
+pub async fn process_batch_with_range<S: FileStore>(
+    writer: &mut EventFileWriterStep<S>,
     events: Vec<EventWithContext>,
     start_version: u64,
     end_version: u64,
@@ -139,12 +138,12 @@ pub async fn process_batch_with_range(
 }
 
 /// Helper to create a fresh writer for tests.
-pub fn new_writer(
-    store: Arc<dyn FileStore>,
+pub fn new_writer<S: FileStore>(
+    store: S,
     config: EventFileProcessorConfig,
     folder_state: InternalFolderState,
     flushed_version: Option<u64>,
-) -> EventFileWriterStep {
+) -> EventFileWriterStep<S> {
     EventFileWriterStep::new(
         store,
         config,

--- a/processor/src/processors/event_file/test_utils.rs
+++ b/processor/src/processors/event_file/test_utils.rs
@@ -111,7 +111,7 @@ pub async fn do_recovery(
 
 /// Process events with batch range derived from the events themselves.
 /// Suitable for most tests that don't care about the scanned range.
-pub async fn process_batch<S: FileStore>(
+pub async fn process_batch<S: FileStore + 'static>(
     writer: &mut EventFileWriterStep<S>,
     events: Vec<EventWithContext>,
 ) -> anyhow::Result<()> {
@@ -123,7 +123,7 @@ pub async fn process_batch<S: FileStore>(
 /// Process events with an explicit scanned range (`start_version..=end_version`,
 /// both inclusive). Use when the test needs the batch to represent a wider scan
 /// than just the matching events (e.g. to test `processed_version` semantics).
-pub async fn process_batch_with_range<S: FileStore>(
+pub async fn process_batch_with_range<S: FileStore + 'static>(
     writer: &mut EventFileWriterStep<S>,
     events: Vec<EventWithContext>,
     start_version: u64,

--- a/processor/src/processors/event_file/tests.rs
+++ b/processor/src/processors/event_file/tests.rs
@@ -24,7 +24,7 @@ use std::{path::PathBuf, sync::Arc};
 #[tokio::test]
 async fn test_recovery_after_buffered_events_not_flushed() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: Arc<LocalFileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
     let config = test_config();
 
     let mut writer = new_writer(
@@ -89,7 +89,7 @@ async fn test_recovery_after_buffered_events_not_flushed() {
 #[tokio::test]
 async fn test_recovery_after_flush_then_more_buffered() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: Arc<LocalFileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
     let mut config = test_config();
     config.max_txns_per_folder = 3;
 
@@ -141,7 +141,7 @@ async fn test_recovery_after_flush_then_more_buffered() {
 #[tokio::test]
 async fn test_folder_txn_count_consistent_across_recovery() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: Arc<LocalFileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
     let mut config = test_config();
     config.max_txns_per_folder = 1000;
     config.max_seconds_between_flushes = 0;
@@ -187,7 +187,7 @@ async fn test_folder_txn_count_consistent_across_recovery() {
 #[tokio::test]
 async fn test_recovery_advances_past_completed_folder() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: Arc<LocalFileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
     let mut config = test_config();
     config.max_txns_per_folder = 3;
 
@@ -264,7 +264,7 @@ async fn test_recovery_advances_past_completed_folder() {
 #[tokio::test]
 async fn test_completed_folder_crash_new_events_go_to_next_folder() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: Arc<LocalFileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
     let mut config = test_config();
     config.max_txns_per_folder = 3;
 
@@ -376,7 +376,7 @@ async fn test_completed_folder_crash_new_events_go_to_next_folder() {
 #[tokio::test]
 async fn test_recovery_prefers_folder_metadata_over_stale_root() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: Arc<LocalFileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
     let config = test_config();
 
     // Simulate a crash between writing folder metadata and root metadata.
@@ -460,7 +460,7 @@ async fn test_recovery_prefers_folder_metadata_over_stale_root() {
 #[tokio::test]
 async fn test_complete_transactions_multi_event_txn_not_split() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: Arc<LocalFileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
     let mut config = test_config();
     config.max_txns_per_folder = 2;
 
@@ -529,7 +529,7 @@ async fn test_complete_transactions_multi_event_txn_not_split() {
 #[tokio::test]
 async fn test_config_mismatch_rejected_on_recovery() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: Arc<LocalFileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
     let config = test_config();
 
     // Write root metadata with the original config. Note:
@@ -582,7 +582,7 @@ async fn test_config_mismatch_rejected_on_recovery() {
 #[tokio::test]
 async fn test_initial_starting_version_mismatch_rejected_on_recovery() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: Arc<LocalFileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
     let config = test_config();
 
     // Root metadata was written with initial_starting_version=0.
@@ -636,7 +636,7 @@ async fn test_initial_starting_version_mismatch_rejected_on_recovery() {
 #[tokio::test]
 async fn test_version_semantics_and_filename_encoding() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: Arc<LocalFileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
     let mut config = test_config();
     config.max_txns_per_folder = 3;
 
@@ -718,7 +718,7 @@ async fn test_version_semantics_and_filename_encoding() {
 #[tokio::test]
 async fn test_data_file_content_matches_after_flush() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: Arc<LocalFileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
     let mut config = test_config();
     config.max_txns_per_folder = 2;
 
@@ -764,7 +764,7 @@ async fn test_data_file_content_matches_after_flush() {
 #[tokio::test]
 async fn test_file_metadata_size_and_counts_match_actual_file() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: Arc<LocalFileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
     let mut config = test_config();
     config.max_txns_per_folder = 3;
 
@@ -834,7 +834,7 @@ async fn test_file_metadata_size_and_counts_match_actual_file() {
 #[tokio::test]
 async fn test_sealed_folder_metadata_not_modified_by_subsequent_writes() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: Arc<LocalFileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
     let mut config = test_config();
     config.max_txns_per_folder = 2;
 
@@ -907,7 +907,7 @@ async fn test_sealed_folder_metadata_not_modified_by_subsequent_writes() {
 #[tokio::test]
 async fn test_no_double_counting_after_partial_flush_and_recovery() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: Arc<LocalFileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
     let mut config = test_config();
     config.max_txns_per_folder = 10;
     config.max_seconds_between_flushes = 0;
@@ -1001,7 +1001,7 @@ async fn test_no_double_counting_after_partial_flush_and_recovery() {
 #[tokio::test]
 async fn test_size_trigger_flush() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: Arc<LocalFileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
     let mut config = test_config();
     config.max_file_size_bytes = 1;
     // Keep other triggers high so only the size trigger fires.
@@ -1082,7 +1082,7 @@ async fn test_size_trigger_flush() {
 #[tokio::test]
 async fn test_multiple_files_per_folder() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: Arc<LocalFileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
     let mut config = test_config();
     config.max_txns_per_folder = 100;
     config.max_seconds_between_flushes = 5;
@@ -1199,7 +1199,7 @@ async fn test_multiple_files_per_folder() {
 #[tokio::test]
 async fn test_empty_batch_advances_processed_version() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: Arc<LocalFileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
     let mut config = test_config();
     config.max_seconds_between_flushes = 0;
 
@@ -1263,7 +1263,7 @@ async fn test_empty_batch_advances_processed_version() {
 #[tokio::test]
 async fn test_processed_version_reflects_batch_range() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: Arc<LocalFileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
     let mut config = test_config();
     config.max_seconds_between_flushes = 0;
 
@@ -1329,7 +1329,7 @@ async fn test_processed_version_reflects_batch_range() {
 #[tokio::test]
 async fn test_recovery_fresh_start_uses_default_starting_version() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: Arc<LocalFileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
     let config = test_config();
 
     // Recover with default_starting_version = 42. No metadata exists on disk.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Add an enum-dispatched event file storage enum and route the existing GCS writer through it.

## Test Plan
- `cargo test -p processor event_file`
- `rustfmt --edition 2024 --check processor/src/processors/event_file/event_file_processor.rs processor/src/processors/event_file/event_file_writer.rs processor/src/processors/event_file/storage.rs processor/src/processors/event_file/test_utils.rs processor/src/processors/event_file/tests.rs integration-tests/src/sdk_tests/event_file_processor_tests.rs`

Note: full `cargo fmt --check` reports pre-existing unrelated formatting diffs in `integration-tests/src/sdk_tests/fungible_asset_processor_tests.rs`, `processor/src/processors/objects/mod.rs`, `processor/src/processors/stake/models/staking_pool_voter.rs`, and `processor/src/utils/counters.rs`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d90aea11-8e91-42e0-a752-8ab0c8e79771"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d90aea11-8e91-42e0-a752-8ab0c8e79771"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

