### PR TITLE
Add local event file storage

### DIFF
--- a/processor/src/processors/event_file/event_file_config.rs
+++ b/processor/src/processors/event_file/event_file_config.rs
@@ -2,6 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
 const fn default_max_file_size_bytes() -> usize {
     50 * 1024 * 1024 // 50 MiB
@@ -26,7 +27,11 @@ pub struct EventFileProcessorConfig {
     pub event_filter_config: EventFileFilterConfig,
 
     // Storage
+    #[serde(default)]
+    pub storage_config: Option<EventFileStorageConfig>,
+    #[serde(default)]
     pub bucket_name: String,
+    #[serde(default)]
     pub bucket_root: String,
     #[serde(default)]
     pub google_application_credentials: Option<String>,
@@ -47,6 +52,20 @@ pub struct EventFileProcessorConfig {
 
     #[serde(default = "default_channel_size")]
     pub channel_size: usize,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum EventFileStorageConfig {
+    Gcs {
+        bucket_name: String,
+        bucket_root: String,
+        #[serde(default)]
+        google_application_credentials: Option<String>,
+    },
+    Local {
+        directory: PathBuf,
+    },
 }
 
 impl EventFileProcessorConfig {

--- a/processor/src/processors/event_file/event_file_processor.rs
+++ b/processor/src/processors/event_file/event_file_processor.rs
@@ -2,11 +2,11 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::{
-    event_file_config::EventFileProcessorConfig,
+    event_file_config::{EventFileProcessorConfig, EventFileStorageConfig},
     event_file_extractor::EventFileExtractorStep,
     event_file_writer::EventFileWriterStep,
     metadata::{InternalFolderState, METADATA_FILE_NAME, RootMetadata},
-    storage::{EventFileStorage, FileStore, GcsFileStore},
+    storage::{EventFileStorage, FileStore, GcsFileStore, LocalFileStore},
 };
 use crate::config::{
     indexer_processor_config::IndexerProcessorConfig, processor_config::ProcessorConfig,
@@ -86,7 +86,7 @@ pub async fn recover_state(
                     "Immutable config mismatch between running config and stored metadata.\n\
                      Stored:  {stored}\n\
                      Current: {current}\n\
-                     If you intentionally changed these fields you must use a fresh GCS prefix.",
+                     If you intentionally changed these fields you must use a fresh storage prefix or directory.",
                     stored = serde_json::to_string_pretty(&root.config)?,
                     current = serde_json::to_string_pretty(&expected)?,
                 );
@@ -254,7 +254,43 @@ impl EventFileProcessor {
         }
     }
 
-    /// Recover from GCS metadata to determine the starting version, current
+    fn resolved_storage_config(&self) -> Result<EventFileStorageConfig> {
+        if let Some(storage_config) = &self.event_file_config.storage_config {
+            return Ok(storage_config.clone());
+        }
+
+        if self.event_file_config.bucket_name.is_empty() {
+            bail!(
+                "event file processor requires either storage_config or bucket_name for legacy GCS storage"
+            );
+        }
+
+        Ok(EventFileStorageConfig::Gcs {
+            bucket_name: self.event_file_config.bucket_name.clone(),
+            bucket_root: self.event_file_config.bucket_root.clone(),
+            google_application_credentials: self
+                .event_file_config
+                .google_application_credentials
+                .clone(),
+        })
+    }
+
+    async fn build_store(&self) -> Result<EventFileStorage> {
+        match self.resolved_storage_config()? {
+            EventFileStorageConfig::Gcs {
+                bucket_name,
+                bucket_root,
+                google_application_credentials,
+            } => Ok(EventFileStorage::Gcs(
+                GcsFileStore::new(bucket_name, bucket_root, google_application_credentials).await?,
+            )),
+            EventFileStorageConfig::Local { directory } => {
+                Ok(EventFileStorage::Local(LocalFileStore::new(directory)))
+            },
+        }
+    }
+
+    /// Recover from storage metadata to determine the starting version, current
     /// folder state, and chain_id. If no metadata exists yet this is a fresh
     /// start and we return defaults without writing anything — the root metadata
     /// is only written once we know the chain_id (from the gRPC stream).
@@ -275,16 +311,7 @@ impl ProcessorTrait for EventFileProcessor {
     }
 
     async fn run_processor(&self) -> Result<()> {
-        let store = Arc::new(EventFileStorage::from(
-            GcsFileStore::new(
-                self.event_file_config.bucket_name.clone(),
-                self.event_file_config.bucket_root.clone(),
-                self.event_file_config
-                    .google_application_credentials
-                    .clone(),
-            )
-            .await?,
-        ));
+        let store = Arc::new(self.build_store().await?);
 
         let recovered_state = self.recover_or_initialize(&store).await?;
 
@@ -300,7 +327,7 @@ impl ProcessorTrait for EventFileProcessor {
             bail!(
                 "Chain ID mismatch: stored metadata has chain_id={stored_chain_id} but \
                  the transaction stream reports chain_id={stream_chain_id}. \
-                 If you intentionally switched chains you must use a fresh GCS prefix."
+                 If you intentionally switched chains you must use a fresh storage prefix or directory."
             );
         }
 

--- a/processor/src/processors/event_file/storage.rs
+++ b/processor/src/processors/event_file/storage.rs
@@ -53,6 +53,7 @@ pub trait FileStore: Send + Sync {
 #[enum_dispatch(FileStore)]
 pub enum EventFileStorage {
     Gcs(GcsFileStore),
+    Local(LocalFileStore),
 }
 
 // ---------------------------------------------------------------------------

--- a/processor/src/processors/event_file/test_utils.rs
+++ b/processor/src/processors/event_file/test_utils.rs
@@ -29,6 +29,7 @@ pub fn test_config() -> EventFileProcessorConfig {
                 event_name: None,
             }],
         },
+        storage_config: None,
         bucket_name: "test".to_string(),
         bucket_root: "test".to_string(),
         google_application_credentials: None,

--- a/processor/src/processors/event_file/tests.rs
+++ b/processor/src/processors/event_file/tests.rs
@@ -2,6 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::{
+    event_file_config::EventFileStorageConfig,
     event_file_processor::recover_state,
     event_file_writer::EventFileWriterStep,
     metadata::{
@@ -18,6 +19,28 @@ use super::{
 use aptos_indexer_processor_sdk::traits::Processable;
 use prost::Message;
 use std::{path::PathBuf, sync::Arc};
+
+#[test]
+fn test_local_storage_config_deserializes_without_gcs_fields() {
+    let config: super::event_file_config::EventFileProcessorConfig =
+        serde_json::from_value(serde_json::json!({
+            "event_filter_config": {
+                "filters": [{ "module_address": "0x1" }]
+            },
+            "storage_config": {
+                "type": "local",
+                "directory": "/tmp/event-files"
+            }
+        }))
+        .unwrap();
+
+    match config.storage_config.unwrap() {
+        EventFileStorageConfig::Local { directory } => {
+            assert_eq!(directory, PathBuf::from("/tmp/event-files"));
+        },
+        other => panic!("expected local storage config, got {other:?}"),
+    }
+}
 
 /// Verify that root metadata is NOT written when nothing has been flushed.
 /// `latest_committed_version` in root metadata only reflects flushed data.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Add a configured local filesystem storage variant for the event file processor.

## Test Plan
- `cargo test -p processor event_file`
- `rustfmt --edition 2024 --check processor/src/processors/event_file/event_file_config.rs processor/src/processors/event_file/event_file_processor.rs processor/src/processors/event_file/storage.rs processor/src/processors/event_file/test_utils.rs processor/src/processors/event_file/tests.rs`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d90aea11-8e91-42e0-a752-8ab0c8e79771"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d90aea11-8e91-42e0-a752-8ab0c8e79771"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

