### PR TITLE
Fix import issue with logging processor

### DIFF
--- a/processor/src/alerting/alerting_dispatcher.rs
+++ b/processor/src/alerting/alerting_dispatcher.rs
@@ -12,7 +12,7 @@ use aptos_indexer_processor_sdk::{
 use async_trait::async_trait;
 use chrono::Utc;
 use std::{collections::HashMap, sync::Arc};
-use tracing::{info, warn};
+use tracing::{debug, warn};
 
 /// Routes matched events to configured sinks. Drops matches older than
 /// `max_alert_age_secs` (set to 0 in replay mode to disable). Each batch
@@ -165,10 +165,9 @@ mod tests {
     fn fresh_events_are_delivered_to_named_sink() {
         let (dispatcher, sink) = dispatcher_with("test_sink", 300);
         dispatcher.dispatch(&matched("r1", vec!["test_sink"], 0), now());
-        assert_eq!(
-            sink.delivered.lock().unwrap().as_slice(),
-            &["r1".to_string()]
-        );
+        assert_eq!(sink.delivered.lock().unwrap().as_slice(), &[
+            "r1".to_string()
+        ]);
     }
 
     #[test]


### PR DESCRIPTION
Fixes this:
```
error: cannot find macro `debug` in this scope
  --> processor/src/alerting/alerting_dispatcher.rs:53:9
   |
53 |         debug!(
   |         ^^^^^
   |
help: consider importing one of these macros
   |
 4 + use log::debug;
   |
 4 + use tracing::debug;
   |

error: unused import: `info`
  --> processor/src/alerting/alerting_dispatcher.rs:15:15
   |
15 | use tracing::{info, warn};
   |               ^^^^
   |
   = note: `-D unused-imports` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(unused_imports)]`
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only fix in alerting dispatch logging; no behavior or security impact beyond restoring a successful build.
> 
> **Overview**
> Fixes a **processor build failure** in `alerting_dispatcher.rs` by aligning `tracing` imports with what the file actually uses: **`debug`** is imported (for the dispatch log line) and the unused **`info`** import is removed.
> 
> A test assertion in the same file is reformatted only; behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a9359852c03ea6263ce1c2dbabf789f0b95e69a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->