### PR TITLE
Let user choose between local and GCS storage for event file processor

### DIFF
--- a/integration-tests/src/sdk_tests/event_file_processor_tests.rs
+++ b/integration-tests/src/sdk_tests/event_file_processor_tests.rs
@@ -23,10 +23,10 @@ use aptos_indexer_processor_sdk::traits::Processable;
 use failpoints::FailScenario;
 use processor::processors::event_file::{
     metadata::{InternalFolderState, METADATA_FILE_NAME, RootMetadata, VersionTracking},
-    storage::{FileStore, LocalFileStore},
+    storage::{FileStore, FileStoreEnum, LocalFileStore},
     test_utils::{do_recovery, make_events, new_writer, process_batch, test_config},
 };
-use std::{path::PathBuf, sync::Arc};
+use std::path::PathBuf;
 
 /// Crash after writing the data file but before updating folder or root
 /// metadata. Recovery should restart from the pre-file version (no metadata
@@ -35,7 +35,7 @@ use std::{path::PathBuf, sync::Arc};
 async fn crash_after_file_write_before_metadata() {
     let scenario = FailScenario::setup();
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: FileStoreEnum = LocalFileStore::new(dir.path().to_path_buf()).into();
     let mut config = test_config();
     config.max_seconds_between_flushes = 0;
 
@@ -78,7 +78,7 @@ async fn crash_after_file_write_before_metadata() {
 async fn crash_after_folder_metadata_before_root() {
     let scenario = FailScenario::setup();
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: FileStoreEnum = LocalFileStore::new(dir.path().to_path_buf()).into();
     let mut config = test_config();
     config.max_seconds_between_flushes = 0;
 
@@ -140,7 +140,7 @@ async fn crash_after_folder_metadata_before_root() {
 async fn crash_with_flushed_and_buffered_events() {
     let scenario = FailScenario::setup();
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: FileStoreEnum = LocalFileStore::new(dir.path().to_path_buf()).into();
     let mut config = test_config();
     config.max_txns_per_folder = 3;
 
@@ -193,7 +193,7 @@ async fn crash_with_flushed_and_buffered_events() {
 async fn repeated_crash_recovery_no_drift() {
     let scenario = FailScenario::setup();
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: FileStoreEnum = LocalFileStore::new(dir.path().to_path_buf()).into();
     let mut config = test_config();
     config.max_txns_per_folder = 1000;
     // With max_seconds_between_flushes=0 the time trigger fires on every new

--- a/processor/src/processors/event_file/event_file_config.rs
+++ b/processor/src/processors/event_file/event_file_config.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
+use super::storage::{FileStoreEnum, GcsFileStore, LocalFileStore};
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
 const fn default_max_file_size_bytes() -> usize {
     50 * 1024 * 1024 // 50 MiB
@@ -26,10 +29,7 @@ pub struct EventFileProcessorConfig {
     pub event_filter_config: EventFileFilterConfig,
 
     // Storage
-    pub bucket_name: String,
-    pub bucket_root: String,
-    #[serde(default)]
-    pub google_application_credentials: Option<String>,
+    pub storage: StorageConfig,
 
     // Flush triggers
     #[serde(default = "default_max_file_size_bytes")]
@@ -86,6 +86,55 @@ impl EventFileProcessorConfig {
             (OutputFormat::Protobuf, CompressionMode::None) => ".pb",
             (OutputFormat::Json, CompressionMode::Lz4) => ".json.lz4",
             (OutputFormat::Json, CompressionMode::None) => ".json",
+        }
+    }
+}
+
+/// Where the processor writes event files. Tagged by `type` so operators can
+/// select either backend in production config, e.g.:
+///
+/// ```yaml
+/// storage:
+///   type: gcs
+///   bucket_name: my-bucket
+///   bucket_root: v2
+/// ```
+///
+/// ```yaml
+/// storage:
+///   type: local
+///   path: /var/lib/event-files
+/// ```
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum StorageConfig {
+    Gcs {
+        bucket_name: String,
+        bucket_root: String,
+        #[serde(default)]
+        google_application_credentials: Option<String>,
+    },
+    Local {
+        path: PathBuf,
+    },
+}
+
+impl StorageConfig {
+    /// Construct the concrete file store backend described by this config.
+    pub async fn build_file_store(&self) -> Result<FileStoreEnum> {
+        match self {
+            StorageConfig::Gcs {
+                bucket_name,
+                bucket_root,
+                google_application_credentials,
+            } => Ok(GcsFileStore::new(
+                bucket_name.clone(),
+                bucket_root.clone(),
+                google_application_credentials.clone(),
+            )
+            .await?
+            .into()),
+            StorageConfig::Local { path } => Ok(LocalFileStore::new(path.clone()).into()),
         }
     }
 }

--- a/processor/src/processors/event_file/event_file_processor.rs
+++ b/processor/src/processors/event_file/event_file_processor.rs
@@ -6,7 +6,7 @@ use super::{
     event_file_extractor::EventFileExtractorStep,
     event_file_writer::EventFileWriterStep,
     metadata::{InternalFolderState, METADATA_FILE_NAME, RootMetadata},
-    storage::{FileStore, GcsFileStore},
+    storage::{FileStore, FileStoreEnum},
 };
 use crate::config::{
     indexer_processor_config::IndexerProcessorConfig, processor_config::ProcessorConfig,
@@ -24,7 +24,7 @@ use aptos_indexer_processor_sdk::{
     traits::{IntoRunnableStep, processor_trait::ProcessorTrait},
     utils::convert::standardize_address,
 };
-use std::{path::PathBuf, sync::Arc};
+use std::path::PathBuf;
 use tracing::info;
 
 /// State recovered from on-disk metadata, used to initialize the writer.
@@ -45,7 +45,7 @@ pub struct RecoveredState {
 /// Exposed as a free function so crash-recovery tests can call it directly
 /// without constructing a full `EventFileProcessor`.
 pub async fn recover_state(
-    store: &Arc<dyn FileStore>,
+    store: &FileStoreEnum,
     config: &EventFileProcessorConfig,
     default_starting_version: u64,
 ) -> Result<RecoveredState> {
@@ -258,7 +258,7 @@ impl EventFileProcessor {
     /// folder state, and chain_id. If no metadata exists yet this is a fresh
     /// start and we return defaults without writing anything — the root metadata
     /// is only written once we know the chain_id (from the gRPC stream).
-    async fn recover_or_initialize(&self, store: &Arc<dyn FileStore>) -> Result<RecoveredState> {
+    async fn recover_or_initialize(&self, store: &FileStoreEnum) -> Result<RecoveredState> {
         recover_state(
             store,
             &self.event_file_config,
@@ -275,16 +275,7 @@ impl ProcessorTrait for EventFileProcessor {
     }
 
     async fn run_processor(&self) -> Result<()> {
-        let store: Arc<dyn FileStore> = Arc::new(
-            GcsFileStore::new(
-                self.event_file_config.bucket_name.clone(),
-                self.event_file_config.bucket_root.clone(),
-                self.event_file_config
-                    .google_application_credentials
-                    .clone(),
-            )
-            .await?,
-        );
+        let store = self.event_file_config.storage.build_file_store().await?;
 
         let recovered_state = self.recover_or_initialize(&store).await?;
 

--- a/processor/src/processors/event_file/event_file_writer.rs
+++ b/processor/src/processors/event_file/event_file_writer.rs
@@ -7,7 +7,7 @@ use super::{
         FileMetadata, InternalFolderState, METADATA_FILE_NAME, RootMetadata, VersionTracking,
     },
     models::{EventFile, EventWithContext},
-    storage::FileStore,
+    storage::{FileStore, FileStoreEnum},
 };
 use anyhow::{Context, Result};
 use aptos_indexer_processor_sdk::{
@@ -18,7 +18,7 @@ use aptos_indexer_processor_sdk::{
 };
 use async_trait::async_trait;
 use prost::Message;
-use std::{path::PathBuf, sync::Arc};
+use std::path::PathBuf;
 use tokio::time::Instant;
 use tracing::info;
 
@@ -49,7 +49,7 @@ impl std::fmt::Display for FlushReason {
 const METADATA_CACHE_CONTROL: &str = "no-store";
 
 pub struct EventFileWriterStep {
-    store: Arc<dyn FileStore>,
+    store: FileStoreEnum,
     config: EventFileProcessorConfig,
     file_extension: &'static str,
     chain_id: u64,
@@ -97,7 +97,7 @@ pub struct EventFileWriterStep {
 
 impl EventFileWriterStep {
     pub fn new(
-        store: Arc<dyn FileStore>,
+        store: FileStoreEnum,
         config: EventFileProcessorConfig,
         chain_id: u64,
         initial_starting_version: u64,

--- a/processor/src/processors/event_file/storage.rs
+++ b/processor/src/processors/event_file/storage.rs
@@ -4,6 +4,7 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
+use enum_dispatch::enum_dispatch;
 use google_cloud_storage::{
     client::{Client as GCSClient, ClientConfig as GcsClientConfig},
     http::{
@@ -30,6 +31,7 @@ const INITIAL_RETRY_DELAY: Duration = Duration::from_millis(500);
 
 /// Abstraction over GCS / local filesystem for writing and reading files.
 #[async_trait]
+#[enum_dispatch]
 pub trait FileStore: Send + Sync {
     /// Write `data` to `path`, optionally setting Cache-Control metadata on the
     /// object. When `cache_control` is `None` the store's default applies (for
@@ -46,10 +48,26 @@ pub trait FileStore: Send + Sync {
     fn max_update_frequency(&self) -> Duration;
 }
 
+/// Statically-dispatched `FileStore` over the concrete backends. Used in place
+/// of `Arc<dyn FileStore>` so callers avoid the vtable indirection of dynamic
+/// dispatch while still supporting either backend at runtime.
+///
+/// Cheaply `Clone`: both backends only hold immutable config plus (for GCS) an
+/// `Arc`-shared client, so clones share the underlying client/connection pool
+/// rather than re-authenticating. This lets callers pass an owned, cloneable
+/// value instead of wrapping it in an `Arc`.
+#[derive(Clone)]
+#[enum_dispatch(FileStore)]
+pub enum FileStoreEnum {
+    Gcs(GcsFileStore),
+    Local(LocalFileStore),
+}
+
 // ---------------------------------------------------------------------------
 // GCS implementation
 // ---------------------------------------------------------------------------
 
+#[derive(Clone)]
 pub struct GcsFileStore {
     client: Arc<GCSClient>,
     bucket_name: String,
@@ -180,6 +198,7 @@ impl FileStore for GcsFileStore {
 // Local filesystem implementation (for testing / development)
 // ---------------------------------------------------------------------------
 
+#[derive(Clone)]
 pub struct LocalFileStore {
     root: PathBuf,
 }

--- a/processor/src/processors/event_file/test_utils.rs
+++ b/processor/src/processors/event_file/test_utils.rs
@@ -6,20 +6,19 @@
 use super::{
     event_file_config::{
         CompressionMode, EventFileFilterConfig, EventFileProcessorConfig, OutputFormat,
-        SingleEventFilter,
+        SingleEventFilter, StorageConfig,
     },
     event_file_processor::{RecoveredState, recover_state},
     event_file_writer::EventFileWriterStep,
     metadata::InternalFolderState,
     models::EventWithContext,
-    storage::FileStore,
+    storage::FileStoreEnum,
 };
 use aptos_indexer_processor_sdk::{
     aptos_protos::{transaction::v1::Event, util::timestamp::Timestamp as AptosTimestamp},
     traits::Processable,
     types::transaction_context::{TransactionContext, TransactionMetadata},
 };
-use std::sync::Arc;
 
 pub fn test_config() -> EventFileProcessorConfig {
     EventFileProcessorConfig {
@@ -30,9 +29,11 @@ pub fn test_config() -> EventFileProcessorConfig {
                 event_name: None,
             }],
         },
-        bucket_name: "test".to_string(),
-        bucket_root: "test".to_string(),
-        google_application_credentials: None,
+        storage: StorageConfig::Gcs {
+            bucket_name: "test".to_string(),
+            bucket_root: "test".to_string(),
+            google_application_credentials: None,
+        },
         max_file_size_bytes: 50 * 1024 * 1024,
         max_txns_per_folder: 100,
         max_seconds_between_flushes: 600,
@@ -104,7 +105,7 @@ pub fn make_batch(
 }
 
 pub async fn do_recovery(
-    store: &Arc<dyn FileStore>,
+    store: &FileStoreEnum,
     config: &EventFileProcessorConfig,
 ) -> RecoveredState {
     recover_state(store, config, 0).await.unwrap()
@@ -140,7 +141,7 @@ pub async fn process_batch_with_range(
 
 /// Helper to create a fresh writer for tests.
 pub fn new_writer(
-    store: Arc<dyn FileStore>,
+    store: FileStoreEnum,
     config: EventFileProcessorConfig,
     folder_state: InternalFolderState,
     flushed_version: Option<u64>,

--- a/processor/src/processors/event_file/tests.rs
+++ b/processor/src/processors/event_file/tests.rs
@@ -9,7 +9,7 @@ use super::{
         VersionTracking,
     },
     models::{EventFile, EventWithContext},
-    storage::{FileStore, LocalFileStore},
+    storage::{FileStore, FileStoreEnum, LocalFileStore},
     test_utils::{
         do_recovery, make_events, make_multi_events, new_writer, process_batch,
         process_batch_with_range, test_config,
@@ -17,14 +17,14 @@ use super::{
 };
 use aptos_indexer_processor_sdk::traits::Processable;
 use prost::Message;
-use std::{path::PathBuf, sync::Arc};
+use std::path::PathBuf;
 
 /// Verify that root metadata is NOT written when nothing has been flushed.
 /// `latest_committed_version` in root metadata only reflects flushed data.
 #[tokio::test]
 async fn test_recovery_after_buffered_events_not_flushed() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: FileStoreEnum = LocalFileStore::new(dir.path().to_path_buf()).into();
     let config = test_config();
 
     let mut writer = new_writer(
@@ -89,7 +89,7 @@ async fn test_recovery_after_buffered_events_not_flushed() {
 #[tokio::test]
 async fn test_recovery_after_flush_then_more_buffered() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: FileStoreEnum = LocalFileStore::new(dir.path().to_path_buf()).into();
     let mut config = test_config();
     config.max_txns_per_folder = 3;
 
@@ -141,7 +141,7 @@ async fn test_recovery_after_flush_then_more_buffered() {
 #[tokio::test]
 async fn test_folder_txn_count_consistent_across_recovery() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: FileStoreEnum = LocalFileStore::new(dir.path().to_path_buf()).into();
     let mut config = test_config();
     config.max_txns_per_folder = 1000;
     config.max_seconds_between_flushes = 0;
@@ -187,7 +187,7 @@ async fn test_folder_txn_count_consistent_across_recovery() {
 #[tokio::test]
 async fn test_recovery_advances_past_completed_folder() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: FileStoreEnum = LocalFileStore::new(dir.path().to_path_buf()).into();
     let mut config = test_config();
     config.max_txns_per_folder = 3;
 
@@ -264,7 +264,7 @@ async fn test_recovery_advances_past_completed_folder() {
 #[tokio::test]
 async fn test_completed_folder_crash_new_events_go_to_next_folder() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: FileStoreEnum = LocalFileStore::new(dir.path().to_path_buf()).into();
     let mut config = test_config();
     config.max_txns_per_folder = 3;
 
@@ -376,7 +376,7 @@ async fn test_completed_folder_crash_new_events_go_to_next_folder() {
 #[tokio::test]
 async fn test_recovery_prefers_folder_metadata_over_stale_root() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: FileStoreEnum = LocalFileStore::new(dir.path().to_path_buf()).into();
     let config = test_config();
 
     // Simulate a crash between writing folder metadata and root metadata.
@@ -460,7 +460,7 @@ async fn test_recovery_prefers_folder_metadata_over_stale_root() {
 #[tokio::test]
 async fn test_complete_transactions_multi_event_txn_not_split() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: FileStoreEnum = LocalFileStore::new(dir.path().to_path_buf()).into();
     let mut config = test_config();
     config.max_txns_per_folder = 2;
 
@@ -529,7 +529,7 @@ async fn test_complete_transactions_multi_event_txn_not_split() {
 #[tokio::test]
 async fn test_config_mismatch_rejected_on_recovery() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: FileStoreEnum = LocalFileStore::new(dir.path().to_path_buf()).into();
     let config = test_config();
 
     // Write root metadata with the original config. Note:
@@ -582,7 +582,7 @@ async fn test_config_mismatch_rejected_on_recovery() {
 #[tokio::test]
 async fn test_initial_starting_version_mismatch_rejected_on_recovery() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: FileStoreEnum = LocalFileStore::new(dir.path().to_path_buf()).into();
     let config = test_config();
 
     // Root metadata was written with initial_starting_version=0.
@@ -636,7 +636,7 @@ async fn test_initial_starting_version_mismatch_rejected_on_recovery() {
 #[tokio::test]
 async fn test_version_semantics_and_filename_encoding() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: FileStoreEnum = LocalFileStore::new(dir.path().to_path_buf()).into();
     let mut config = test_config();
     config.max_txns_per_folder = 3;
 
@@ -718,7 +718,7 @@ async fn test_version_semantics_and_filename_encoding() {
 #[tokio::test]
 async fn test_data_file_content_matches_after_flush() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: FileStoreEnum = LocalFileStore::new(dir.path().to_path_buf()).into();
     let mut config = test_config();
     config.max_txns_per_folder = 2;
 
@@ -764,7 +764,7 @@ async fn test_data_file_content_matches_after_flush() {
 #[tokio::test]
 async fn test_file_metadata_size_and_counts_match_actual_file() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: FileStoreEnum = LocalFileStore::new(dir.path().to_path_buf()).into();
     let mut config = test_config();
     config.max_txns_per_folder = 3;
 
@@ -834,7 +834,7 @@ async fn test_file_metadata_size_and_counts_match_actual_file() {
 #[tokio::test]
 async fn test_sealed_folder_metadata_not_modified_by_subsequent_writes() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: FileStoreEnum = LocalFileStore::new(dir.path().to_path_buf()).into();
     let mut config = test_config();
     config.max_txns_per_folder = 2;
 
@@ -907,7 +907,7 @@ async fn test_sealed_folder_metadata_not_modified_by_subsequent_writes() {
 #[tokio::test]
 async fn test_no_double_counting_after_partial_flush_and_recovery() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: FileStoreEnum = LocalFileStore::new(dir.path().to_path_buf()).into();
     let mut config = test_config();
     config.max_txns_per_folder = 10;
     config.max_seconds_between_flushes = 0;
@@ -1001,7 +1001,7 @@ async fn test_no_double_counting_after_partial_flush_and_recovery() {
 #[tokio::test]
 async fn test_size_trigger_flush() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: FileStoreEnum = LocalFileStore::new(dir.path().to_path_buf()).into();
     let mut config = test_config();
     config.max_file_size_bytes = 1;
     // Keep other triggers high so only the size trigger fires.
@@ -1082,7 +1082,7 @@ async fn test_size_trigger_flush() {
 #[tokio::test]
 async fn test_multiple_files_per_folder() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: FileStoreEnum = LocalFileStore::new(dir.path().to_path_buf()).into();
     let mut config = test_config();
     config.max_txns_per_folder = 100;
     config.max_seconds_between_flushes = 5;
@@ -1199,7 +1199,7 @@ async fn test_multiple_files_per_folder() {
 #[tokio::test]
 async fn test_empty_batch_advances_processed_version() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: FileStoreEnum = LocalFileStore::new(dir.path().to_path_buf()).into();
     let mut config = test_config();
     config.max_seconds_between_flushes = 0;
 
@@ -1263,7 +1263,7 @@ async fn test_empty_batch_advances_processed_version() {
 #[tokio::test]
 async fn test_processed_version_reflects_batch_range() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: FileStoreEnum = LocalFileStore::new(dir.path().to_path_buf()).into();
     let mut config = test_config();
     config.max_seconds_between_flushes = 0;
 
@@ -1329,7 +1329,7 @@ async fn test_processed_version_reflects_batch_range() {
 #[tokio::test]
 async fn test_recovery_fresh_start_uses_default_starting_version() {
     let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn FileStore> = Arc::new(LocalFileStore::new(dir.path().to_path_buf()));
+    let store: FileStoreEnum = LocalFileStore::new(dir.path().to_path_buf()).into();
     let config = test_config();
 
     // Recover with default_starting_version = 42. No metadata exists on disk.


### PR DESCRIPTION
## Summary

The event file processor already had both an implementation for storing data in GCS and another for storing data locally, but the latter was only used in tests and you couldn't use it in production. This PR changes that, you now have to choose between them as part of the processor config.

This change is not backwards compatible but I figure that's okay because we're only running this processor in one place at the moment that we fully control, we can update the config as we update the processor.

## Test Plan

See that CI passes.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2f6cded80bbb5e1592f42ce14ce6fe203ee55cb2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->