### PR TITLE
[alerting] Expose alerting metrics on the prometheus sink's own /metrics endpoint

### DIFF
--- a/processor/example-config-alerting.yaml
+++ b/processor/example-config-alerting.yaml
@@ -14,6 +14,16 @@ server_config:
     # Default: "live" (set when omitted).
     instance_label: live
 
+    # ---- Metrics endpoint ---------------------------------------------------
+    # The alerting counters (event_match_total, event_field_value_total,
+    # event_pipeline_lag_seconds, ...) register into the `prometheus` crate's
+    # global registry, which the server-framework's own /metrics
+    # (health_check_port, above) does NOT serve. The prometheus sink therefore
+    # hosts its own scrape endpoint at `/metrics` on this port — point your
+    # scraper here.
+    # Default: 9101 (set when omitted).
+    metrics_port: 9101
+
     # ---- Run shape: live (default) vs replay --------------------------------
     # `from_version` / `to_version` are both optional. Unset means LIVE mode:
     # the processor starts at the chain's current tip and runs forever.

--- a/processor/src/alerting/alerting_processor.rs
+++ b/processor/src/alerting/alerting_processor.rs
@@ -2,8 +2,11 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::{
-    alerting_dispatcher::AlertDispatcherStep, alerting_extractor::AlertingExtractorStep,
-    app_config::AlertingAppConfig, filter_compiler::compile_transaction_filter, sinks::build_sinks,
+    alerting_dispatcher::AlertDispatcherStep,
+    alerting_extractor::AlertingExtractorStep,
+    app_config::AlertingAppConfig,
+    filter_compiler::compile_transaction_filter,
+    sinks::{build_sinks, prometheus::serve_metrics},
 };
 use crate::utils::counters::log_match_counter_summary;
 use anyhow::{Result, bail};
@@ -14,7 +17,7 @@ use aptos_indexer_processor_sdk::{
     traits::{IntoRunnableStep, processor_trait::ProcessorTrait},
     utils::convert::standardize_address,
 };
-use tracing::{debug, info};
+use tracing::{debug, error, info};
 
 /// Live-first alerting application. No checkpoint table; extended downtime
 /// is handled by an operator-driven replay deploy.
@@ -58,6 +61,16 @@ impl ProcessorTrait for AlertingProcessor {
 
         let starting_version = alerting.from_version;
         let ending_version = alerting.to_version;
+
+        // Expose the alerting counters (registered in the global `prometheus`
+        // registry) on their own endpoint — the SDK's /metrics serves a
+        // different registry and won't include them.
+        let metrics_port = alerting.metrics_port;
+        tokio::spawn(async move {
+            if let Err(e) = serve_metrics(metrics_port).await {
+                error!(error = ?e, port = metrics_port, "alerting metrics endpoint exited");
+            }
+        });
 
         info!(
             instance = alerting.instance_label.as_str(),

--- a/processor/src/alerting/config.rs
+++ b/processor/src/alerting/config.rs
@@ -29,6 +29,10 @@ fn default_instance_label() -> String {
     "live".to_string()
 }
 
+const fn default_metrics_port() -> u16 {
+    9101
+}
+
 /// Top-level config for the alerting processor.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -55,6 +59,14 @@ pub struct AlertingProcessorConfig {
     /// distinct value so PromQL can separate replay from live signal.
     #[serde(default = "default_instance_label")]
     pub instance_label: String,
+
+    /// Port for the Prometheus scrape endpoint exposing the alerting counters
+    /// (event_match_total, event_pipeline_lag_seconds, ...). These register
+    /// into the `prometheus` crate's global registry, which the SDK's own
+    /// /metrics (health_check_port) does not serve — so the prometheus sink
+    /// hosts its own endpoint here.
+    #[serde(default = "default_metrics_port")]
+    pub metrics_port: u16,
 
     /// Chain ID this config is bound to. Bails at startup on mismatch.
     pub chain_id: u64,
@@ -194,6 +206,7 @@ mod tests {
             from_version: None,
             to_version: None,
             instance_label: "test".to_string(),
+            metrics_port: default_metrics_port(),
             chain_id: 1,
         }
     }

--- a/processor/src/alerting/sinks/prometheus.rs
+++ b/processor/src/alerting/sinks/prometheus.rs
@@ -8,6 +8,54 @@ use crate::{
         EVENT_FIELD_VALUE_OVERFLOW_TOTAL, EVENT_FIELD_VALUE_TOTAL, EVENT_MATCH_TOTAL,
     },
 };
+use anyhow::Result;
+use hyper::{
+    Body, Method, Request, Response, Server, StatusCode,
+    service::{make_service_fn, service_fn},
+};
+use prometheus::{Encoder, TextEncoder};
+use std::{convert::Infallible, net::SocketAddr};
+use tracing::info;
+
+/// Encode the global `prometheus` (tikv) registry — where the alerting
+/// counters in `counters.rs` register — into the text exposition format.
+/// The SDK's server only serves its own (autometrics/prometheus-client)
+/// registry, so these metrics would otherwise never be scraped.
+fn render_metrics() -> Vec<u8> {
+    let mut buf = Vec::new();
+    // encode() only fails on a broken io::Write; a Vec never errors.
+    let _ = TextEncoder::new().encode(&prometheus::gather(), &mut buf);
+    buf
+}
+
+async fn handle(req: Request<Body>) -> std::result::Result<Response<Body>, Infallible> {
+    if req.method() == Method::GET && req.uri().path() == "/metrics" {
+        Ok(Response::builder()
+            .status(StatusCode::OK)
+            .header("Content-Type", TextEncoder::new().format_type())
+            .body(Body::from(render_metrics()))
+            .expect("building /metrics response is infallible"))
+    } else {
+        Ok(Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(Body::empty())
+            .expect("building 404 response is infallible"))
+    }
+}
+
+/// Serve the alerting Prometheus counters on `0.0.0.0:port` at `/metrics`.
+/// Runs until the process exits; intended to be `tokio::spawn`ed alongside
+/// the pipeline.
+pub async fn serve_metrics(port: u16) -> Result<()> {
+    let addr = SocketAddr::from(([0, 0, 0, 0], port));
+    let make_svc = make_service_fn(|_conn| async { Ok::<_, Infallible>(service_fn(handle)) });
+    info!(
+        port,
+        "Prometheus sink metrics endpoint listening on /metrics"
+    );
+    Server::bind(&addr).serve(make_svc).await?;
+    Ok(())
+}
 
 pub struct PrometheusSink {
     instance_label: String,
@@ -112,5 +160,28 @@ mod tests {
             .with_label_values(&["test_rule", "amount", &instance])
             .get();
         assert_eq!(value, 42);
+    }
+
+    // The whole point of the sink's endpoint: counters registered in the
+    // global `prometheus` registry must show up in the rendered exposition.
+    #[test]
+    fn render_metrics_includes_alerting_counters() {
+        let instance = format!(
+            "render_{}",
+            chrono::Utc::now().timestamp_nanos_opt().unwrap()
+        );
+        EVENT_MATCH_TOTAL
+            .with_label_values(&["render_rule", "render::type", &instance])
+            .inc();
+
+        let body = String::from_utf8(render_metrics()).unwrap();
+        assert!(
+            body.contains("event_match_total"),
+            "rendered metrics missing event_match_total:\n{body}"
+        );
+        assert!(
+            body.contains(&instance),
+            "rendered metrics missing the just-incremented series (instance={instance})"
+        );
     }
 }


### PR DESCRIPTION
## Problem

The alerting processor's custom counters (`event_match_total`, `event_field_value_total`, `event_pipeline_lag_seconds`, …) register into the **`prometheus` (tikv) crate's global default registry** via `counters.rs`. But the SDK server-framework's `/metrics` (`health_check_port`) only serves the **autometrics / prometheus-client** registry. The two are never bridged, so none of these metrics are ever exposed or scraped — confirmed on a live mainnet pod (only `aptos_procsdk_*` + autometrics appear) and by their total absence in VictoriaMetrics.

## Fix

The prometheus sink hosts its own hyper `/metrics` endpoint over `prometheus::gather()` on a configurable `metrics_port` (default `9101`). Scrape that port; the SDK's `health_check_port` stays for health/liveness. No new dependencies (`hyper`/`prometheus` already in the crate).

## Testing

- `cargo test -p processor alerting::` — 33 pass, incl. new `render_metrics_includes_alerting_counters`
- `cargo clippy -p processor` clean; nightly `rustfmt` clean
- **Verified live on mainnet** (this branch's image): the sink serves `/metrics:9101`, and `event_pipeline_lag_seconds` + `event_match_total` (including the payload-conditioned and `emit_field_values` rules) now flow through to VictoriaMetrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)