### PR TITLE
Treat GCS download 404 as missing object in event file store

### DIFF
--- a/processor/src/processors/event_file/storage.rs
+++ b/processor/src/processors/event_file/storage.rs
@@ -183,7 +183,13 @@ impl FileStore for GcsFileStore {
             .await
         {
             Ok(data) => Ok(Some(data)),
+            // A 404 means the object is absent -> `Ok(None)`. Media downloads can
+            // surface it as either error variant depending on whether the JSON
+            // error body parsed, so match both.
             Err(GcsError::Response(ref resp)) if resp.code == 404 => Ok(None),
+            Err(GcsError::HttpClient(ref e)) if e.status().map(|s| s.as_u16()) == Some(404) => {
+                Ok(None)
+            },
             Err(e) => Err(e).context(format!("Failed to download {object_name}")),
         }
     }


### PR DESCRIPTION
## Problem

`event-file-processor` crashed on restart with:

```
Recovered from existing metadata  folder=578
Error: Failed to download shelbynet/v5/578/metadata.json
Caused by: HTTP status client error (404 Not Found) for url (.../578/metadata.json?alt=media)
```

Root metadata legitimately pointed at folder 578 before any data was flushed into it — on sparse-event chains like shelbynet the writer advances `current_folder_index` and persists root metadata while the new folder is still empty, so its `metadata.json` doesn't exist yet. Recovery's "case 2" (`event_file_processor.rs`) is built to handle exactly this by expecting `get_file` to return `Ok(None)` for the missing folder metadata and falling back to root's values.

## Root cause

`GcsFileStore::get_file` only normalized one shape of 404 to `Ok(None)`:

```rust
Err(GcsError::Response(ref resp)) if resp.code == 404 => Ok(None),
```

But `download_object` (the `?alt=media` media path) runs the response through `check_response_status`, which only yields `GcsError::Response` when GCS's JSON error body deserializes into its strict `ErrorResponse`. When that parse fails it falls back to `GcsError::HttpClient(reqwest::Error)` — which is what a media-download 404 returns (hence the reqwest-style `HTTP status client error` message in the log). That variant slipped past the only 404 arm and propagated as a fatal error.

Only the download path is affected; uploads and the JSON get-object path produce `GcsError::Response`, which is why this stayed hidden until a restart landed on an empty current folder.

## Fix

Match both error variants of a 404 so an absent object maps to `Ok(None)`, while transient network/auth failures still propagate as fatal:

```rust
Err(GcsError::Response(ref resp)) if resp.code == 404 => Ok(None),
Err(GcsError::HttpClient(ref e)) if e.status().map(|s| s.as_u16()) == Some(404) => Ok(None),
```

No new dependency — `.status().as_u16()` is called through the bound `&reqwest::Error` without naming the type, avoiding a direct `reqwest` dep and the version-coupling that comes with it.

## Testing

`cargo check -p processor` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow error-handling change in GCS reads; only affects absent-object detection and does not alter writes or non-404 failures.
> 
> **Overview**
> **`GcsFileStore::get_file`** now maps **404 Not Found** to **`Ok(None)`** when GCS returns it as **`GcsError::HttpClient`** (typical for `?alt=media` downloads), not only when it arrives as **`GcsError::Response`**.
> 
> That aligns GCS with how **`LocalFileStore`** already treats missing files and lets **`recover_state`** handle an empty current folder (root metadata points at a folder whose `metadata.json` is not written yet) instead of failing restart with a fatal download error. Other errors still propagate unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f50138494e8f776e742ce5d8495e3b06e510ea47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->