### PR TITLE
Drop unused/redundant indexes

### DIFF
--- a/processor/src/db/migrations/2026-07-17-000000_drop_unused_indexes/down.sql
+++ b/processor/src/db/migrations/2026-07-17-000000_drop_unused_indexes/down.sql
@@ -1,0 +1,5 @@
+-- Recreate the real indexes. The lm1_* were invalid orphans and are intentionally not restored.
+CREATE INDEX IF NOT EXISTS o_object_skh_idx ON objects (object_address, state_key_hash);
+CREATE INDEX IF NOT EXISTS o_insat_idx ON objects (inserted_at);
+CREATE INDEX IF NOT EXISTS faa_insat_idx ON fungible_asset_activities (inserted_at);
+CREATE INDEX IF NOT EXISTS cufab_insat_index ON current_fungible_asset_balances (inserted_at);

--- a/processor/src/db/migrations/2026-07-17-000000_drop_unused_indexes/down.sql
+++ b/processor/src/db/migrations/2026-07-17-000000_drop_unused_indexes/down.sql
@@ -1,5 +1,6 @@
 -- Recreate the real indexes. The lm1_* were invalid orphans and are intentionally not restored.
 CREATE INDEX IF NOT EXISTS o_object_skh_idx ON objects (object_address, state_key_hash);
+CREATE INDEX IF NOT EXISTS co_object_skh_idx ON current_objects (object_address, state_key_hash);
 CREATE INDEX IF NOT EXISTS o_insat_idx ON objects (inserted_at);
 CREATE INDEX IF NOT EXISTS faa_insat_idx ON fungible_asset_activities (inserted_at);
 CREATE INDEX IF NOT EXISTS cufab_insat_index ON current_fungible_asset_balances (inserted_at);

--- a/processor/src/db/migrations/2026-07-17-000000_drop_unused_indexes/up.sql
+++ b/processor/src/db/migrations/2026-07-17-000000_drop_unused_indexes/up.sql
@@ -6,6 +6,7 @@ DROP INDEX IF EXISTS o_object_skh_idx;
 DROP INDEX IF EXISTS o_insat_idx;
 DROP INDEX IF EXISTS faa_insat_idx;
 DROP INDEX IF EXISTS cufab_insat_index;
+DROP INDEX IF EXISTS co_object_skh_idx;
 
 -- Orphaned invalid indexes left by the v1->v2 migration (never valid).
 DROP INDEX IF EXISTS lm1_ccb_ct_a_cfaab_index;

--- a/processor/src/db/migrations/2026-07-17-000000_drop_unused_indexes/up.sql
+++ b/processor/src/db/migrations/2026-07-17-000000_drop_unused_indexes/up.sql
@@ -1,0 +1,20 @@
+-- Drop unused/redundant indexes (INC-22633). Confirmed 0 reads on the read-pool replicas;
+-- dropped by hand with DROP INDEX CONCURRENTLY on prod, so this is a no-op there and applies
+-- on fresh/small DBs.
+
+DROP INDEX IF EXISTS o_object_skh_idx;
+DROP INDEX IF EXISTS o_insat_idx;
+DROP INDEX IF EXISTS faa_insat_idx;
+DROP INDEX IF EXISTS cufab_insat_index;
+
+-- Orphaned invalid indexes left by the v1->v2 migration (never valid).
+DROP INDEX IF EXISTS lm1_ccb_ct_a_cfaab_index;
+DROP INDEX IF EXISTS lm1_cv_ci_tv_index;
+DROP INDEX IF EXISTS lm1_ccb_ct_a_index;
+DROP INDEX IF EXISTS lm1_curr_to_oa_tt_ltv_index;
+DROP INDEX IF EXISTS lm1_curr_to_oa_tt_am_ltv_index;
+DROP INDEX IF EXISTS lm1_ca_ct_a_index;
+DROP INDEX IF EXISTS lm1_ca_oa_ct_at_index;
+DROP INDEX IF EXISTS lm1_ca_oa_igf_index;
+DROP INDEX IF EXISTS lm1_ca_ct_at_a_index;
+DROP INDEX IF EXISTS lm1_ta_tdih_pv_index;


### PR DESCRIPTION
Drops unused/redundant indexes on the high-write history tables plus orphaned invalid `lm1_*` indexes left by the v1→v2 migration:

- `o_object_skh_idx`, `o_insat_idx` (on `objects`) — redundant with the PK / no read-side usage
- `faa_insat_idx` (on `fungible_asset_activities`), `cufab_insat_index` (on `current_fungible_asset_balances`) — unused `inserted_at` indexes
- 10 invalid `lm1_*` indexes (0-byte failed builds from the v1→v2 migration)

All confirmed unused (0 scans on the read-pool replicas + negligible on the primary). On prod they were dropped by hand with `DROP INDEX CONCURRENTLY`, so this migration is a no-op there and applies on fresh/small DBs. ~817 GB reclaimed + reduced write-amplification on the busiest tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes indexes on high-write indexer tables; impact is low if usage was truly zero, but misclassification could hurt query performance until rollback or re-index.
> 
> **Overview**
> Adds migration `2026-07-17-000000_drop_unused_indexes` to **remove indexes that were already dropped on prod** (`DROP INDEX CONCURRENTLY`) so fresh and smaller environments match production.
> 
> The **up** migration drops five indexes on `objects`, `current_objects`, `fungible_asset_activities`, and `current_fungible_asset_balances` (redundant `(object_address, state_key_hash)` pairs and unused `inserted_at` indexes), plus **ten invalid `lm1_*` indexes** left from the v1→v2 migration. The **down** migration recreates only those five “real” indexes; the `lm1_*` orphans are intentionally not restored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24e9c4a80a867e4773bc0ff838b162697cacfac0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->