### PR TITLE
Add Shelby blobs processor

### DIFF
--- a/processor/example-config-shelby-blobs.yaml
+++ b/processor/example-config-shelby-blobs.yaml
@@ -1,0 +1,18 @@
+health_check_port: 8085
+server_config:
+  processor_config:
+    type: shelby_blobs_processor
+    channel_size: 100
+    # Address of the Shelby contract to index; differs per network.
+    deployer_address: "0xf3f4bf6b43f5a4fa82e3634465a624a95016160aa60ee237d857a0ef2d246d80"
+  transaction_stream_config:
+    indexer_grpc_data_service_address: "https://grpc.shelbynet.aptoslabs.com:443"
+    auth_token: "AUTH_TOKEN"
+    request_name_header: "shelby_blobs_processor"
+  processor_mode:
+    type: "default"
+    # The version the contract above was published at; nothing to index before it.
+    initial_starting_version: 169957809
+  db_config:
+    type: postgres_config
+    connection_string: postgresql://postgres:@localhost:5432/example

--- a/processor/src/config/indexer_processor_config.rs
+++ b/processor/src/config/indexer_processor_config.rs
@@ -27,8 +27,9 @@ use crate::{
         fungible_asset::fungible_asset_processor::FungibleAssetProcessor,
         gas_fees::gas_fee_processor::GasFeeProcessor,
         monitoring::monitoring_processor::MonitoringProcessor,
-        objects::objects_processor::ObjectsProcessor, stake::stake_processor::StakeProcessor,
-        token_v2::token_v2_processor::TokenV2Processor,
+        objects::objects_processor::ObjectsProcessor,
+        shelby_blobs::shelby_blobs_processor::ShelbyBlobsProcessor,
+        stake::stake_processor::StakeProcessor, token_v2::token_v2_processor::TokenV2Processor,
         user_transaction::user_transaction_processor::UserTransactionProcessor,
     },
 };
@@ -108,6 +109,10 @@ impl RunnableConfig for IndexerProcessorConfig {
             ProcessorConfig::ObjectsProcessor(_) => {
                 let objects_processor = ObjectsProcessor::new(self.clone()).await?;
                 objects_processor.run_processor().await
+            },
+            ProcessorConfig::ShelbyBlobsProcessor(_) => {
+                let shelby_blobs_processor = ShelbyBlobsProcessor::new(self.clone()).await?;
+                shelby_blobs_processor.run_processor().await
             },
             ProcessorConfig::EventFileProcessor(_) => {
                 let event_file_processor = EventFileProcessor::new(self.clone()).await?;

--- a/processor/src/config/processor_config.rs
+++ b/processor/src/config/processor_config.rs
@@ -37,6 +37,7 @@ use crate::{
             objects_processor::ObjectsProcessorConfig,
             v2_objects_models::{ParquetCurrentObject, ParquetObject},
         },
+        shelby_blobs::shelby_blobs_processor::ShelbyBlobsProcessorConfig,
         stake::{
             models::{
                 delegator_activities::ParquetDelegatedStakingActivity,
@@ -109,6 +110,7 @@ pub enum ProcessorConfig {
     StakeProcessor(StakeProcessorConfig),
     TokenV2Processor(TokenV2ProcessorConfig),
     ObjectsProcessor(ObjectsProcessorConfig),
+    ShelbyBlobsProcessor(ShelbyBlobsProcessorConfig),
     MonitoringProcessor(DefaultProcessorConfig),
     GasFeeProcessor(DefaultProcessorConfig),
     // Event file processor (GCS-based, no DB)

--- a/processor/src/db/migrations/2026-07-13-000000_shelby_blobs/down.sql
+++ b/processor/src/db/migrations/2026-07-13-000000_shelby_blobs/down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS placement_group_slots;
+DROP TABLE IF EXISTS blob_activities;
+DROP TABLE IF EXISTS blobs;

--- a/processor/src/db/migrations/2026-07-13-000000_shelby_blobs/up.sql
+++ b/processor/src/db/migrations/2026-07-13-000000_shelby_blobs/up.sql
@@ -1,0 +1,68 @@
+-- Shelby blob indexer tables. Move numeric types (u8/u32/u64) map to NUMERIC.
+-- last_transaction_version backs the latest-version-wins upsert guard.
+
+-- Current state, keyed by the per-registration uid (object_name is reusable).
+CREATE TABLE blobs (
+    uid                      NUMERIC NOT NULL,
+    object_name              TEXT NOT NULL,
+    owner                    VARCHAR(66) NOT NULL,
+    blob_commitment          TEXT NOT NULL,
+    encoding                 TEXT NOT NULL,
+    encryption               TEXT NOT NULL,
+    slice_address            VARCHAR(66) NOT NULL,
+    placement_group          VARCHAR(66) NOT NULL,
+    created_at               NUMERIC NOT NULL,
+    updated_at               NUMERIC NOT NULL,
+    expires_at               NUMERIC NOT NULL,
+    size                     NUMERIC NOT NULL,
+    num_chunksets            NUMERIC NOT NULL,
+    payment_amount           NUMERIC NOT NULL,
+    is_persisted             NUMERIC NOT NULL,
+    is_committed             NUMERIC NOT NULL,
+    is_deleted               NUMERIC NOT NULL,
+    etag                     TEXT,
+    deletion_reason          TEXT,
+    last_transaction_version BIGINT NOT NULL,
+    inserted_at              TIMESTAMP NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (uid)
+);
+
+CREATE INDEX idx_blobs_object_name ON blobs (object_name);
+CREATE INDEX idx_blobs_owner_object_name ON blobs (owner, object_name);
+CREATE INDEX idx_blobs_created_at_active ON blobs (created_at DESC) WHERE is_deleted = 0;
+-- The "current objects" view: a name resolves to the one committed, undeleted
+-- blob bound to it. Overwrites leave a dead row per version, so prefix listing
+-- needs the predicate in the index rather than as a post-scan filter.
+CREATE INDEX idx_blobs_current_objects ON blobs (owner, object_name)
+    WHERE is_committed = 1 AND is_deleted = 0;
+
+-- Append-only activity log.
+CREATE TABLE blob_activities (
+    transaction_hash    VARCHAR(66) NOT NULL,
+    event_type          TEXT NOT NULL,
+    event_index         NUMERIC NOT NULL,
+    uid                 NUMERIC NOT NULL,
+    object_name         TEXT NOT NULL,
+    owner               VARCHAR(66),
+    transaction_version NUMERIC NOT NULL,
+    timestamp           TIMESTAMP NOT NULL,
+    inserted_at         TIMESTAMP NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (transaction_hash, event_type, event_index)
+);
+
+CREATE INDEX idx_blob_act_uid ON blob_activities (uid);
+CREATE INDEX idx_blob_act_owner_version ON blob_activities (owner, transaction_version DESC);
+CREATE INDEX idx_blob_act_version ON blob_activities (transaction_version DESC);
+
+CREATE TABLE placement_group_slots (
+    placement_group          VARCHAR(66) NOT NULL,
+    slot_index               NUMERIC NOT NULL,
+    storage_provider         VARCHAR(66) NOT NULL,
+    status                   TEXT NOT NULL,
+    updated_at               NUMERIC NOT NULL,
+    last_transaction_version BIGINT NOT NULL,
+    inserted_at              TIMESTAMP NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (placement_group, slot_index)
+);
+
+CREATE INDEX idx_pg_slots_status ON placement_group_slots (status);

--- a/processor/src/db/migrations/2026-07-13-000000_shelby_blobs/up.sql
+++ b/processor/src/db/migrations/2026-07-13-000000_shelby_blobs/up.sql
@@ -40,11 +40,11 @@ CREATE INDEX idx_blobs_current_objects ON blobs (owner, object_name)
 CREATE TABLE blob_activities (
     transaction_hash    VARCHAR(66) NOT NULL,
     event_type          TEXT NOT NULL,
-    event_index         NUMERIC NOT NULL,
+    event_index         BIGINT NOT NULL,
     uid                 NUMERIC NOT NULL,
     object_name         TEXT NOT NULL,
     owner               VARCHAR(66),
-    transaction_version NUMERIC NOT NULL,
+    transaction_version BIGINT NOT NULL,
     timestamp           TIMESTAMP NOT NULL,
     inserted_at         TIMESTAMP NOT NULL DEFAULT NOW(),
     PRIMARY KEY (transaction_hash, event_type, event_index)

--- a/processor/src/db/schema.rs
+++ b/processor/src/db/schema.rs
@@ -96,12 +96,12 @@ diesel::table! {
         #[max_length = 66]
         transaction_hash -> Varchar,
         event_type -> Text,
-        event_index -> Numeric,
+        event_index -> Int8,
         uid -> Numeric,
         object_name -> Text,
         #[max_length = 66]
         owner -> Nullable<Varchar>,
-        transaction_version -> Numeric,
+        transaction_version -> Int8,
         timestamp -> Timestamp,
         inserted_at -> Timestamp,
     }

--- a/processor/src/db/schema.rs
+++ b/processor/src/db/schema.rs
@@ -92,6 +92,65 @@ diesel::table! {
 }
 
 diesel::table! {
+    blob_activities (transaction_hash, event_type, event_index) {
+        #[max_length = 66]
+        transaction_hash -> Varchar,
+        event_type -> Text,
+        event_index -> Numeric,
+        uid -> Numeric,
+        object_name -> Text,
+        #[max_length = 66]
+        owner -> Nullable<Varchar>,
+        transaction_version -> Numeric,
+        timestamp -> Timestamp,
+        inserted_at -> Timestamp,
+    }
+}
+
+diesel::table! {
+    blobs (uid) {
+        uid -> Numeric,
+        object_name -> Text,
+        #[max_length = 66]
+        owner -> Varchar,
+        blob_commitment -> Text,
+        encoding -> Text,
+        encryption -> Text,
+        #[max_length = 66]
+        slice_address -> Varchar,
+        #[max_length = 66]
+        placement_group -> Varchar,
+        created_at -> Numeric,
+        updated_at -> Numeric,
+        expires_at -> Numeric,
+        size -> Numeric,
+        num_chunksets -> Numeric,
+        payment_amount -> Numeric,
+        is_persisted -> Numeric,
+        is_committed -> Numeric,
+        is_deleted -> Numeric,
+        etag -> Nullable<Text>,
+        deletion_reason -> Nullable<Text>,
+        last_transaction_version -> Int8,
+        inserted_at -> Timestamp,
+    }
+}
+
+diesel::table! {
+    placement_group_slots (placement_group, slot_index) {
+        #[max_length = 66]
+        placement_group -> Varchar,
+        slot_index -> Numeric,
+        #[max_length = 66]
+        storage_provider -> Varchar,
+        status -> Text,
+        updated_at -> Numeric,
+        last_transaction_version -> Int8,
+        inserted_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     confidential_asset_activities (transaction_version, event_index) {
         transaction_version -> Int8,
         event_index -> Int8,
@@ -945,6 +1004,8 @@ diesel::allow_tables_to_appear_in_same_query!(
     ans_primary_name_v2,
     auth_key_account_addresses,
     backfill_processor_status,
+    blob_activities,
+    blobs,
     block_metadata_transactions,
     collections_v2,
     confidential_asset_activities,
@@ -979,6 +1040,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     move_modules,
     nft_points,
     objects,
+    placement_group_slots,
     processor_status,
     proposal_votes,
     public_key_auth_keys,

--- a/processor/src/processors/mod.rs
+++ b/processor/src/processors/mod.rs
@@ -12,6 +12,7 @@ pub mod gas_fees;
 pub mod monitoring;
 pub mod objects;
 pub mod processor_status_saver;
+pub mod shelby_blobs;
 pub mod stake;
 pub mod token_v2;
 pub mod user_transaction;

--- a/processor/src/processors/shelby_blobs/mod.rs
+++ b/processor/src/processors/shelby_blobs/mod.rs
@@ -1,0 +1,10 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+pub mod models;
+pub mod shelby_blobs_extractor;
+pub mod shelby_blobs_processor;
+pub mod shelby_blobs_storer;
+
+#[cfg(test)]
+mod tests;

--- a/processor/src/processors/shelby_blobs/models/mod.rs
+++ b/processor/src/processors/shelby_blobs/models/mod.rs
@@ -1,0 +1,7 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+mod read;
+mod write;
+
+pub use write::{BlobActivity, BlobUpdate, NewBlob, PlacementGroupSlot, ShelbyBlobData};

--- a/processor/src/processors/shelby_blobs/models/read.rs
+++ b/processor/src/processors/shelby_blobs/models/read.rs
@@ -1,0 +1,110 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Move JSON deserialization types for the Shelby `blob_metadata` and
+//! `placement_group` events. Aptos serializes u64 as JSON strings and
+//! u8/u16/u32 as JSON numbers; enums carry a `__variant__` tag.
+
+use aptos_indexer_processor_sdk::utils::convert::deserialize_from_string;
+use serde::Deserialize;
+
+/// A Move enum value; we keep only its variant name (the `__variant__` tag).
+#[derive(Debug, Deserialize)]
+pub(super) struct MoveVariant {
+    #[serde(rename = "__variant__")]
+    pub variant: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct BlobRegisteredEvent {
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub uid: u64,
+    pub object_name: String,
+    pub owner: String,
+    pub blob_commitment: String,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub blob_size: u64,
+    pub chunkset_count: u32,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub creation_micros: u64,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub expiration_micros: u64,
+    pub slice_address: String,
+    pub placement_group_address: String,
+    pub encoding: MoveVariant,
+    pub encryption: MoveVariant,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub payment_amount: u64,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct BlobPersistedEvent {
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub uid: u64,
+    pub object_name: String,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub persisted_at_micros: u64,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct ObjectCommittedEvent {
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub uid: u64,
+    pub object_name: String,
+    pub owner: String,
+    pub etag: String,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub committed_at_micros: u64,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct BlobDeletedEvent {
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub uid: u64,
+    pub object_name: String,
+    pub reason: MoveVariant,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct ObjectDeletedEvent {
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub uid: u64,
+    pub object_name: String,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub deleted_at_micros: u64,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct BlobExpirationExtendedEvent {
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub uid: u64,
+    pub object_name: String,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub new_expiration_micros: u64,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub updated_at_micros: u64,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct ObjectCommitRejectedEvent {
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub uid: u64,
+    pub object_name: String,
+    pub owner: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct StorageProviderSlotEvent {
+    pub placement_group_address: String,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub slot_index: u64,
+    pub storage_provider_address: String,
+    /// Unifies the per-event timestamp field (`activated_at`/`assigned_at`/`vacated_at`).
+    #[serde(
+        alias = "activated_at",
+        alias = "assigned_at",
+        alias = "vacated_at",
+        deserialize_with = "deserialize_from_string"
+    )]
+    pub updated_at: u64,
+}

--- a/processor/src/processors/shelby_blobs/models/write.rs
+++ b/processor/src/processors/shelby_blobs/models/write.rs
@@ -1,0 +1,307 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Diesel models and event parsing for the `blobs`, `blob_activities`, and
+//! `placement_group_slots` tables.
+//!
+//! Only `BlobRegisteredEvent` carries every NOT-NULL `blobs` column, so it is the
+//! sole row creator ([`NewBlob`]); other events are partial [`BlobUpdate`]s.
+
+use super::read::*;
+use crate::schema::{blob_activities, blobs, placement_group_slots};
+use aptos_indexer_processor_sdk::{
+    aptos_indexer_transaction_stream::utils::time::parse_timestamp,
+    aptos_protos::transaction::v1::{Event, Transaction, transaction::TxnData},
+    utils::convert::standardize_address,
+};
+use bigdecimal::BigDecimal;
+use chrono::NaiveDateTime;
+use field_count::FieldCount;
+use serde::{Deserialize, Serialize};
+
+pub const BLOB_METADATA_MODULE: &str = "blob_metadata";
+pub const PLACEMENT_GROUP_MODULE: &str = "placement_group";
+
+// ─── Diesel models ──────────────────────────────────────────────────────────
+
+#[derive(Clone, Debug, Deserialize, FieldCount, Insertable, Serialize)]
+#[diesel(table_name = blobs)]
+pub struct NewBlob {
+    pub uid: BigDecimal,
+    pub object_name: String,
+    pub owner: String,
+    pub blob_commitment: String,
+    pub encoding: String,
+    pub encryption: String,
+    pub slice_address: String,
+    pub placement_group: String,
+    pub created_at: BigDecimal,
+    pub updated_at: BigDecimal,
+    pub expires_at: BigDecimal,
+    pub size: BigDecimal,
+    pub num_chunksets: BigDecimal,
+    pub payment_amount: BigDecimal,
+    pub is_persisted: BigDecimal,
+    pub is_committed: BigDecimal,
+    pub is_deleted: BigDecimal,
+    pub etag: Option<String>,
+    pub deletion_reason: Option<String>,
+    pub last_transaction_version: i64,
+}
+
+#[derive(Clone, Debug, Deserialize, FieldCount, Insertable, Serialize)]
+#[diesel(table_name = blob_activities)]
+pub struct BlobActivity {
+    pub transaction_hash: String,
+    pub event_type: String,
+    pub event_index: BigDecimal,
+    pub uid: BigDecimal,
+    pub object_name: String,
+    pub owner: Option<String>,
+    pub transaction_version: BigDecimal,
+    pub timestamp: NaiveDateTime,
+}
+
+#[derive(Clone, Debug, Deserialize, FieldCount, Insertable, Serialize)]
+#[diesel(table_name = placement_group_slots)]
+pub struct PlacementGroupSlot {
+    pub placement_group: String,
+    pub slot_index: BigDecimal,
+    pub storage_provider: String,
+    pub status: String,
+    pub updated_at: BigDecimal,
+    pub last_transaction_version: i64,
+}
+
+/// A partial update to an existing `blobs` row; `None` columns are left unchanged.
+#[derive(Clone, Debug, Default)]
+pub struct BlobUpdate {
+    pub uid: BigDecimal,
+    pub last_transaction_version: i64,
+    pub updated_at: Option<BigDecimal>,
+    pub expires_at: Option<BigDecimal>,
+    pub owner: Option<String>,
+    pub etag: Option<String>,
+    pub deletion_reason: Option<String>,
+    pub is_persisted: Option<BigDecimal>,
+    pub is_committed: Option<BigDecimal>,
+    pub is_deleted: Option<BigDecimal>,
+}
+
+// ─── Parsed output for one context of transactions ──────────────────────────
+
+#[derive(Default)]
+pub struct ShelbyBlobData {
+    pub new_blobs: Vec<NewBlob>,
+    pub blob_updates: Vec<BlobUpdate>,
+    pub activities: Vec<BlobActivity>,
+    pub pg_slots: Vec<PlacementGroupSlot>,
+}
+
+impl ShelbyBlobData {
+    pub fn extend(&mut self, other: ShelbyBlobData) {
+        self.new_blobs.extend(other.new_blobs);
+        self.blob_updates.extend(other.blob_updates);
+        self.activities.extend(other.activities);
+        self.pg_slots.extend(other.pg_slots);
+    }
+
+    /// `deployer` is the standardized contract address emitting these events.
+    pub fn from_transaction(transaction: &Transaction, deployer: &str) -> Self {
+        let mut data = Self::default();
+
+        let txn_data = match transaction.txn_data.as_ref() {
+            Some(d) => d,
+            None => return data,
+        };
+        let txn_version = transaction.version as i64;
+        let txn_version_bd = BigDecimal::from(transaction.version);
+        let info = transaction.info.as_ref().expect("Transaction info missing");
+        let txn_hash = format!("0x{}", hex::encode(&info.hash));
+        let txn_timestamp = parse_timestamp(
+            transaction
+                .timestamp
+                .as_ref()
+                .expect("Transaction timestamp missing"),
+            txn_version,
+        )
+        .naive_utc();
+
+        let events = match txn_data {
+            TxnData::User(inner) => &inner.events,
+            TxnData::Genesis(inner) => &inner.events,
+            TxnData::BlockMetadata(inner) => &inner.events,
+            TxnData::Validator(inner) => &inner.events,
+            TxnData::StateCheckpoint(_) | TxnData::BlockEpilogue(_) => return data,
+        };
+
+        let blob_prefix = format!("{deployer}::{BLOB_METADATA_MODULE}::");
+        let pg_prefix = format!("{deployer}::{PLACEMENT_GROUP_MODULE}::");
+
+        for (idx, event) in events.iter().enumerate() {
+            if let Some(short) = event.type_str.strip_prefix(&blob_prefix) {
+                data.handle_blob_event(
+                    short,
+                    event,
+                    &txn_hash,
+                    txn_version,
+                    &txn_version_bd,
+                    txn_timestamp,
+                    idx as u64,
+                );
+            } else if let Some(short) = event.type_str.strip_prefix(&pg_prefix) {
+                data.handle_pg_event(short, event, txn_version);
+            }
+        }
+        data
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn handle_blob_event(
+        &mut self,
+        short: &str,
+        event: &Event,
+        txn_hash: &str,
+        txn_version: i64,
+        txn_version_bd: &BigDecimal,
+        txn_timestamp: NaiveDateTime,
+        event_index: u64,
+    ) -> Option<()> {
+        // (uid, object_name, owner) for the blob_activities row.
+        let activity: (u64, String, Option<String>) = match short {
+            "BlobRegisteredEvent" => {
+                let e = deser::<BlobRegisteredEvent>(short, &event.data);
+                let owner = standardize_address(&e.owner);
+                self.new_blobs.push(NewBlob {
+                    uid: BigDecimal::from(e.uid),
+                    object_name: e.object_name.clone(),
+                    owner: owner.clone(),
+                    blob_commitment: e.blob_commitment,
+                    encoding: e.encoding.variant,
+                    encryption: e.encryption.variant,
+                    slice_address: standardize_address(&e.slice_address),
+                    placement_group: standardize_address(&e.placement_group_address),
+                    created_at: BigDecimal::from(e.creation_micros),
+                    updated_at: BigDecimal::from(e.creation_micros),
+                    expires_at: BigDecimal::from(e.expiration_micros),
+                    size: BigDecimal::from(e.blob_size),
+                    num_chunksets: BigDecimal::from(e.chunkset_count),
+                    payment_amount: BigDecimal::from(e.payment_amount),
+                    is_persisted: BigDecimal::from(0u64),
+                    is_committed: BigDecimal::from(0u64),
+                    is_deleted: BigDecimal::from(0u64),
+                    etag: None,
+                    deletion_reason: None,
+                    last_transaction_version: txn_version,
+                });
+                (e.uid, e.object_name, Some(owner))
+            },
+            "BlobPersistedEvent" => {
+                let e = deser::<BlobPersistedEvent>(short, &event.data);
+                self.blob_updates.push(BlobUpdate {
+                    uid: BigDecimal::from(e.uid),
+                    last_transaction_version: txn_version,
+                    updated_at: Some(BigDecimal::from(e.persisted_at_micros)),
+                    is_persisted: Some(BigDecimal::from(1u64)),
+                    ..Default::default()
+                });
+                (e.uid, e.object_name, None)
+            },
+            "ObjectCommittedEvent" => {
+                let e = deser::<ObjectCommittedEvent>(short, &event.data);
+                let owner = standardize_address(&e.owner);
+                self.blob_updates.push(BlobUpdate {
+                    uid: BigDecimal::from(e.uid),
+                    last_transaction_version: txn_version,
+                    updated_at: Some(BigDecimal::from(e.committed_at_micros)),
+                    owner: Some(owner.clone()),
+                    etag: Some(e.etag),
+                    is_committed: Some(BigDecimal::from(1u64)),
+                    ..Default::default()
+                });
+                (e.uid, e.object_name, Some(owner))
+            },
+            "BlobDeletedEvent" => {
+                // Carries no timestamp: sets is_deleted but not updated_at.
+                let e = deser::<BlobDeletedEvent>(short, &event.data);
+                self.blob_updates.push(BlobUpdate {
+                    uid: BigDecimal::from(e.uid),
+                    last_transaction_version: txn_version,
+                    deletion_reason: Some(e.reason.variant),
+                    is_deleted: Some(BigDecimal::from(1u64)),
+                    ..Default::default()
+                });
+                (e.uid, e.object_name, None)
+            },
+            "ObjectDeletedEvent" => {
+                let e = deser::<ObjectDeletedEvent>(short, &event.data);
+                self.blob_updates.push(BlobUpdate {
+                    uid: BigDecimal::from(e.uid),
+                    last_transaction_version: txn_version,
+                    updated_at: Some(BigDecimal::from(e.deleted_at_micros)),
+                    ..Default::default()
+                });
+                (e.uid, e.object_name, None)
+            },
+            "BlobExpirationExtendedEvent" => {
+                let e = deser::<BlobExpirationExtendedEvent>(short, &event.data);
+                self.blob_updates.push(BlobUpdate {
+                    uid: BigDecimal::from(e.uid),
+                    last_transaction_version: txn_version,
+                    updated_at: Some(BigDecimal::from(e.updated_at_micros)),
+                    expires_at: Some(BigDecimal::from(e.new_expiration_micros)),
+                    ..Default::default()
+                });
+                (e.uid, e.object_name, None)
+            },
+            "ObjectCommitRejectedEvent" => {
+                // Activity-only; no blobs row change.
+                let e = deser::<ObjectCommitRejectedEvent>(short, &event.data);
+                (e.uid, e.object_name, Some(standardize_address(&e.owner)))
+            },
+            _ => return None,
+        };
+
+        let (uid, object_name, owner) = activity;
+        self.activities.push(BlobActivity {
+            transaction_hash: txn_hash.to_string(),
+            event_type: event.type_str.clone(),
+            event_index: BigDecimal::from(event_index),
+            uid: BigDecimal::from(uid),
+            object_name,
+            owner,
+            transaction_version: txn_version_bd.clone(),
+            timestamp: txn_timestamp,
+        });
+        Some(())
+    }
+
+    fn handle_pg_event(&mut self, short: &str, event: &Event, txn_version: i64) -> Option<()> {
+        let status = match short {
+            "StorageProviderActivatedEvent" => "active",
+            "StorageProviderAssignedEvent" => "joining",
+            "StorageProviderVacatedEvent" => "left",
+            _ => return None,
+        };
+        let e = deser::<StorageProviderSlotEvent>(short, &event.data);
+        self.pg_slots.push(PlacementGroupSlot {
+            placement_group: standardize_address(&e.placement_group_address),
+            slot_index: BigDecimal::from(e.slot_index),
+            storage_provider: standardize_address(&e.storage_provider_address),
+            status: status.to_string(),
+            updated_at: BigDecimal::from(e.updated_at),
+            last_transaction_version: txn_version,
+        });
+        Some(())
+    }
+}
+
+/// Panics on failure: a parse error for an event we index means the on-chain
+/// shape diverged from this processor's target schema.
+fn deser<'a, T: serde::Deserialize<'a>>(event_type: &str, data: &'a str) -> T {
+    serde_json::from_str::<T>(data).unwrap_or_else(|e| {
+        panic!(
+            "Failed to deserialize shelby event '{event_type}' (contract schema mismatch?): {e} — data: {data}"
+        )
+    })
+}

--- a/processor/src/processors/shelby_blobs/models/write.rs
+++ b/processor/src/processors/shelby_blobs/models/write.rs
@@ -54,11 +54,11 @@ pub struct NewBlob {
 pub struct BlobActivity {
     pub transaction_hash: String,
     pub event_type: String,
-    pub event_index: BigDecimal,
+    pub event_index: i64,
     pub uid: BigDecimal,
     pub object_name: String,
     pub owner: Option<String>,
-    pub transaction_version: BigDecimal,
+    pub transaction_version: i64,
     pub timestamp: NaiveDateTime,
 }
 
@@ -115,7 +115,6 @@ impl ShelbyBlobData {
             None => return data,
         };
         let txn_version = transaction.version as i64;
-        let txn_version_bd = BigDecimal::from(transaction.version);
         let info = transaction.info.as_ref().expect("Transaction info missing");
         let txn_hash = format!("0x{}", hex::encode(&info.hash));
         let txn_timestamp = parse_timestamp(
@@ -145,9 +144,8 @@ impl ShelbyBlobData {
                     event,
                     &txn_hash,
                     txn_version,
-                    &txn_version_bd,
                     txn_timestamp,
-                    idx as u64,
+                    idx as i64,
                 );
             } else if let Some(short) = event.type_str.strip_prefix(&pg_prefix) {
                 data.handle_pg_event(short, event, txn_version);
@@ -163,9 +161,8 @@ impl ShelbyBlobData {
         event: &Event,
         txn_hash: &str,
         txn_version: i64,
-        txn_version_bd: &BigDecimal,
         txn_timestamp: NaiveDateTime,
-        event_index: u64,
+        event_index: i64,
     ) -> Option<()> {
         // (uid, object_name, owner) for the blob_activities row.
         let activity: (u64, String, Option<String>) = match short {
@@ -266,11 +263,11 @@ impl ShelbyBlobData {
         self.activities.push(BlobActivity {
             transaction_hash: txn_hash.to_string(),
             event_type: event.type_str.clone(),
-            event_index: BigDecimal::from(event_index),
+            event_index,
             uid: BigDecimal::from(uid),
             object_name,
             owner,
-            transaction_version: txn_version_bd.clone(),
+            transaction_version: txn_version,
             timestamp: txn_timestamp,
         });
         Some(())

--- a/processor/src/processors/shelby_blobs/shelby_blobs_extractor.rs
+++ b/processor/src/processors/shelby_blobs/shelby_blobs_extractor.rs
@@ -1,0 +1,53 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::processors::shelby_blobs::models::ShelbyBlobData;
+use anyhow::Result;
+use aptos_indexer_processor_sdk::{
+    aptos_protos::transaction::v1::Transaction,
+    traits::{AsyncStep, NamedStep, Processable, async_step::AsyncRunType},
+    types::transaction_context::TransactionContext,
+    utils::errors::ProcessorError,
+};
+use async_trait::async_trait;
+
+pub struct ShelbyBlobsExtractor
+where
+    Self: Sized + Send + 'static,
+{
+    /// Standardized address of the Shelby contract whose events we index.
+    pub deployer_address: String,
+}
+
+#[async_trait]
+impl Processable for ShelbyBlobsExtractor {
+    type Input = Vec<Transaction>;
+    type Output = ShelbyBlobData;
+    type RunType = AsyncRunType;
+
+    async fn process(
+        &mut self,
+        transactions: TransactionContext<Vec<Transaction>>,
+    ) -> Result<Option<TransactionContext<ShelbyBlobData>>, ProcessorError> {
+        let mut data = ShelbyBlobData::default();
+        for txn in transactions.data.iter() {
+            data.extend(ShelbyBlobData::from_transaction(
+                txn,
+                &self.deployer_address,
+            ));
+        }
+
+        Ok(Some(TransactionContext {
+            data,
+            metadata: transactions.metadata,
+        }))
+    }
+}
+
+impl AsyncStep for ShelbyBlobsExtractor {}
+
+impl NamedStep for ShelbyBlobsExtractor {
+    fn name(&self) -> String {
+        "shelby_blobs_extractor".to_string()
+    }
+}

--- a/processor/src/processors/shelby_blobs/shelby_blobs_processor.rs
+++ b/processor/src/processors/shelby_blobs/shelby_blobs_processor.rs
@@ -1,0 +1,158 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::{
+    MIGRATIONS,
+    config::{
+        db_config::DbConfig,
+        indexer_processor_config::IndexerProcessorConfig,
+        processor_config::{DefaultProcessorConfig, ProcessorConfig},
+    },
+    processors::{
+        processor_status_saver::{
+            PostgresProcessorStatusSaver, get_end_version, get_starting_version,
+        },
+        shelby_blobs::{
+            shelby_blobs_extractor::ShelbyBlobsExtractor, shelby_blobs_storer::ShelbyBlobsStorer,
+        },
+    },
+};
+use anyhow::Result;
+use aptos_indexer_processor_sdk::{
+    aptos_indexer_transaction_stream::TransactionStreamConfig,
+    builder::ProcessorBuilder,
+    common_steps::{
+        DEFAULT_UPDATE_PROCESSOR_STATUS_SECS, TransactionStreamStep, VersionTrackerStep,
+    },
+    postgres::utils::{
+        checkpoint::PostgresChainIdChecker,
+        database::{ArcDbPool, new_db_pool, run_migrations},
+    },
+    traits::{IntoRunnableStep, processor_trait::ProcessorTrait},
+    utils::{chain_id_check::check_or_update_chain_id, convert::standardize_address},
+};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, info};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ShelbyBlobsProcessorConfig {
+    #[serde(flatten)]
+    pub default_config: DefaultProcessorConfig,
+    /// Address of the Shelby contract whose events are indexed (per-network).
+    pub deployer_address: String,
+}
+
+pub struct ShelbyBlobsProcessor {
+    pub config: IndexerProcessorConfig,
+    pub db_pool: ArcDbPool,
+}
+
+impl ShelbyBlobsProcessor {
+    pub async fn new(config: IndexerProcessorConfig) -> Result<Self> {
+        match config.db_config {
+            DbConfig::PostgresConfig(ref postgres_config) => {
+                let conn_pool = new_db_pool(
+                    &postgres_config.connection_string,
+                    Some(postgres_config.db_pool_size),
+                )
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "Failed to create connection pool for PostgresConfig: {:?}",
+                        e
+                    )
+                })?;
+
+                Ok(Self {
+                    config,
+                    db_pool: conn_pool,
+                })
+            },
+            _ => Err(anyhow::anyhow!(
+                "Invalid db config for ShelbyBlobsProcessor {:?}",
+                config.db_config
+            )),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ProcessorTrait for ShelbyBlobsProcessor {
+    fn name(&self) -> &'static str {
+        self.config.processor_config.name()
+    }
+
+    async fn run_processor(&self) -> Result<()> {
+        if let DbConfig::PostgresConfig(ref postgres_config) = self.config.db_config {
+            run_migrations(
+                postgres_config.connection_string.clone(),
+                self.db_pool.clone(),
+                MIGRATIONS,
+            )
+            .await;
+        }
+
+        let (starting_version, ending_version) = (
+            get_starting_version(&self.config, self.db_pool.clone()).await?,
+            get_end_version(&self.config, self.db_pool.clone()).await?,
+        );
+
+        check_or_update_chain_id(
+            &self.config.transaction_stream_config,
+            &PostgresChainIdChecker::new(self.db_pool.clone()),
+        )
+        .await?;
+
+        let processor_config = match &self.config.processor_config {
+            ProcessorConfig::ShelbyBlobsProcessor(processor_config) => processor_config,
+            _ => return Err(anyhow::anyhow!("Processor config is wrong type")),
+        };
+        let channel_size = processor_config.default_config.channel_size;
+
+        let transaction_stream = TransactionStreamStep::new(TransactionStreamConfig {
+            starting_version,
+            request_ending_version: ending_version,
+            ..self.config.transaction_stream_config.clone()
+        })
+        .await?;
+
+        let extractor = ShelbyBlobsExtractor {
+            deployer_address: standardize_address(&processor_config.deployer_address),
+        };
+        let storer = ShelbyBlobsStorer::new(
+            self.db_pool.clone(),
+            processor_config
+                .default_config
+                .per_table_chunk_sizes
+                .clone(),
+        );
+        let version_tracker = VersionTrackerStep::new(
+            PostgresProcessorStatusSaver::new(self.config.clone(), self.db_pool.clone()),
+            DEFAULT_UPDATE_PROCESSOR_STATUS_SECS,
+        );
+
+        let (_, buffer_receiver) = ProcessorBuilder::new_with_inputless_first_step(
+            transaction_stream.into_runnable_step(),
+        )
+        .connect_to(extractor.into_runnable_step(), channel_size)
+        .connect_to(storer.into_runnable_step(), channel_size)
+        .connect_to(version_tracker.into_runnable_step(), channel_size)
+        .end_and_return_output_receiver(channel_size);
+
+        loop {
+            match buffer_receiver.recv().await {
+                Ok(txn_context) => {
+                    debug!(
+                        "Finished processing versions [{:?}, {:?}]",
+                        txn_context.metadata.start_version, txn_context.metadata.end_version,
+                    );
+                },
+                Err(e) => {
+                    info!("No more transactions in channel: {:?}", e);
+                    break Ok(());
+                },
+            }
+        }
+    }
+}

--- a/processor/src/processors/shelby_blobs/shelby_blobs_storer.rs
+++ b/processor/src/processors/shelby_blobs/shelby_blobs_storer.rs
@@ -1,0 +1,321 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::{
+    processors::shelby_blobs::models::{
+        BlobActivity, BlobUpdate, NewBlob, PlacementGroupSlot, ShelbyBlobData,
+    },
+    schema,
+};
+use ahash::AHashMap;
+use anyhow::Result;
+use aptos_indexer_processor_sdk::{
+    postgres::utils::database::{ArcDbPool, execute_in_chunks, get_config_table_chunk_size},
+    traits::{AsyncStep, NamedStep, Processable, async_step::AsyncRunType},
+    types::transaction_context::TransactionContext,
+    utils::errors::ProcessorError,
+};
+use async_trait::async_trait;
+use bigdecimal::BigDecimal;
+use diesel::{
+    ExpressionMethods,
+    pg::{Pg, upsert::excluded},
+    query_builder::{QueryFragment, QueryId},
+    query_dsl::methods::FilterDsl,
+    sql_types::{Array, BigInt, Nullable, Numeric, Text},
+};
+use diesel_async::RunQueryDsl;
+use std::collections::HashMap;
+
+pub struct ShelbyBlobsStorer
+where
+    Self: Sized + Send + 'static,
+{
+    conn_pool: ArcDbPool,
+    per_table_chunk_sizes: AHashMap<String, usize>,
+}
+
+impl ShelbyBlobsStorer {
+    pub fn new(conn_pool: ArcDbPool, per_table_chunk_sizes: AHashMap<String, usize>) -> Self {
+        Self {
+            conn_pool,
+            per_table_chunk_sizes,
+        }
+    }
+}
+
+#[async_trait]
+impl Processable for ShelbyBlobsStorer {
+    type Input = ShelbyBlobData;
+    type Output = ();
+    type RunType = AsyncRunType;
+
+    async fn process(
+        &mut self,
+        input: TransactionContext<ShelbyBlobData>,
+    ) -> Result<Option<TransactionContext<Self::Output>>, ProcessorError> {
+        let ShelbyBlobData {
+            new_blobs,
+            blob_updates,
+            activities,
+            pg_slots,
+        } = input.data;
+
+        // Postgres rejects a conflict target touched twice in one do_update statement.
+        let new_blobs = dedup_by_max_version(
+            new_blobs,
+            |b| b.uid.to_string(),
+            |b| b.last_transaction_version,
+        );
+        let pg_slots = dedup_by_max_version(
+            pg_slots,
+            |s| format!("{}:{}", s.placement_group, s.slot_index),
+            |s| s.last_transaction_version,
+        );
+        let blob_updates = merge_blob_updates(blob_updates);
+
+        let (start_version, end_version) =
+            (input.metadata.start_version, input.metadata.end_version);
+
+        // Register creates the row; it must land before partial updates targeting it.
+        execute_in_chunks(
+            self.conn_pool.clone(),
+            insert_blobs_query,
+            &new_blobs,
+            get_config_table_chunk_size::<NewBlob>("blobs", &self.per_table_chunk_sizes),
+        )
+        .await
+        .map_err(|e| store_error(start_version, end_version, &e))?;
+
+        self.apply_blob_updates(&blob_updates)
+            .await
+            .map_err(|e| store_error(start_version, end_version, &e))?;
+
+        execute_in_chunks(
+            self.conn_pool.clone(),
+            insert_pg_slots_query,
+            &pg_slots,
+            get_config_table_chunk_size::<PlacementGroupSlot>(
+                "placement_group_slots",
+                &self.per_table_chunk_sizes,
+            ),
+        )
+        .await
+        .map_err(|e| store_error(start_version, end_version, &e))?;
+
+        execute_in_chunks(
+            self.conn_pool.clone(),
+            insert_activities_query,
+            &activities,
+            get_config_table_chunk_size::<BlobActivity>(
+                "blob_activities",
+                &self.per_table_chunk_sizes,
+            ),
+        )
+        .await
+        .map_err(|e| store_error(start_version, end_version, &e))?;
+
+        Ok(Some(TransactionContext {
+            data: (),
+            metadata: input.metadata,
+        }))
+    }
+}
+
+impl ShelbyBlobsStorer {
+    /// One guarded statement: `COALESCE` preserves unset columns, the version
+    /// guard keeps latest-version-wins.
+    async fn apply_blob_updates(
+        &self,
+        updates: &[BlobUpdate],
+    ) -> Result<(), diesel::result::Error> {
+        if updates.is_empty() {
+            return Ok(());
+        }
+
+        let uids: Vec<BigDecimal> = updates.iter().map(|u| u.uid.clone()).collect();
+        let ltvs: Vec<i64> = updates.iter().map(|u| u.last_transaction_version).collect();
+        let updated_at: Vec<Option<BigDecimal>> =
+            updates.iter().map(|u| u.updated_at.clone()).collect();
+        let expires_at: Vec<Option<BigDecimal>> =
+            updates.iter().map(|u| u.expires_at.clone()).collect();
+        let owner: Vec<Option<String>> = updates.iter().map(|u| u.owner.clone()).collect();
+        let etag: Vec<Option<String>> = updates.iter().map(|u| u.etag.clone()).collect();
+        let deletion_reason: Vec<Option<String>> =
+            updates.iter().map(|u| u.deletion_reason.clone()).collect();
+        let is_persisted: Vec<Option<BigDecimal>> =
+            updates.iter().map(|u| u.is_persisted.clone()).collect();
+        let is_committed: Vec<Option<BigDecimal>> =
+            updates.iter().map(|u| u.is_committed.clone()).collect();
+        let is_deleted: Vec<Option<BigDecimal>> =
+            updates.iter().map(|u| u.is_deleted.clone()).collect();
+
+        const SQL: &str = "
+            UPDATE blobs AS b SET
+                updated_at = COALESCE(v.updated_at, b.updated_at),
+                expires_at = COALESCE(v.expires_at, b.expires_at),
+                owner = COALESCE(v.owner, b.owner),
+                etag = COALESCE(v.etag, b.etag),
+                deletion_reason = COALESCE(v.deletion_reason, b.deletion_reason),
+                is_persisted = COALESCE(v.is_persisted, b.is_persisted),
+                is_committed = COALESCE(v.is_committed, b.is_committed),
+                is_deleted = COALESCE(v.is_deleted, b.is_deleted),
+                last_transaction_version = v.ltv
+            FROM unnest($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+                AS v(uid, ltv, updated_at, expires_at, owner, etag,
+                      deletion_reason, is_persisted, is_committed, is_deleted)
+            WHERE b.uid = v.uid AND b.last_transaction_version <= v.ltv
+        ";
+
+        let mut conn = self.conn_pool.get().await.map_err(|e| {
+            diesel::result::Error::QueryBuilderError(format!("pool error: {e}").into())
+        })?;
+
+        diesel::sql_query(SQL)
+            .bind::<Array<Numeric>, _>(uids)
+            .bind::<Array<BigInt>, _>(ltvs)
+            .bind::<Array<Nullable<Numeric>>, _>(updated_at)
+            .bind::<Array<Nullable<Numeric>>, _>(expires_at)
+            .bind::<Array<Nullable<Text>>, _>(owner)
+            .bind::<Array<Nullable<Text>>, _>(etag)
+            .bind::<Array<Nullable<Text>>, _>(deletion_reason)
+            .bind::<Array<Nullable<Numeric>>, _>(is_persisted)
+            .bind::<Array<Nullable<Numeric>>, _>(is_committed)
+            .bind::<Array<Nullable<Numeric>>, _>(is_deleted)
+            .execute(&mut conn)
+            .await?;
+
+        Ok(())
+    }
+}
+
+impl NamedStep for ShelbyBlobsStorer {
+    fn name(&self) -> String {
+        "shelby_blobs_storer".to_string()
+    }
+}
+
+impl AsyncStep for ShelbyBlobsStorer {}
+
+fn store_error(start_version: u64, end_version: u64, e: &dyn std::fmt::Debug) -> ProcessorError {
+    ProcessorError::DBStoreError {
+        message: format!("Failed to store versions {start_version} to {end_version}: {e:?}"),
+        query: None,
+    }
+}
+
+/// Keeps, per key, only the row with the highest transaction version.
+fn dedup_by_max_version<T, K, V>(items: Vec<T>, key: K, version: V) -> Vec<T>
+where
+    K: Fn(&T) -> String,
+    V: Fn(&T) -> i64,
+{
+    let mut by_key: HashMap<String, T> = HashMap::new();
+    for item in items {
+        let k = key(&item);
+        match by_key.get(&k) {
+            Some(existing) if version(existing) >= version(&item) => {},
+            _ => {
+                by_key.insert(k, item);
+            },
+        }
+    }
+    by_key.into_values().collect()
+}
+
+/// Merges same-`uid` updates within a batch; later (higher-version) `Some` wins.
+fn merge_blob_updates(updates: Vec<BlobUpdate>) -> Vec<BlobUpdate> {
+    let mut by_uid: HashMap<String, BlobUpdate> = HashMap::new();
+    for u in updates {
+        let key = u.uid.to_string();
+        match by_uid.get_mut(&key) {
+            Some(m) => {
+                m.last_transaction_version =
+                    m.last_transaction_version.max(u.last_transaction_version);
+                if u.updated_at.is_some() {
+                    m.updated_at = u.updated_at;
+                }
+                if u.expires_at.is_some() {
+                    m.expires_at = u.expires_at;
+                }
+                if u.owner.is_some() {
+                    m.owner = u.owner;
+                }
+                if u.etag.is_some() {
+                    m.etag = u.etag;
+                }
+                if u.deletion_reason.is_some() {
+                    m.deletion_reason = u.deletion_reason;
+                }
+                if u.is_persisted.is_some() {
+                    m.is_persisted = u.is_persisted;
+                }
+                if u.is_committed.is_some() {
+                    m.is_committed = u.is_committed;
+                }
+                if u.is_deleted.is_some() {
+                    m.is_deleted = u.is_deleted;
+                }
+            },
+            None => {
+                by_uid.insert(key, u);
+            },
+        }
+    }
+    by_uid.into_values().collect()
+}
+
+fn insert_blobs_query(items: Vec<NewBlob>) -> impl QueryFragment<Pg> + QueryId + Send {
+    use schema::blobs::dsl::*;
+    diesel::insert_into(schema::blobs::table)
+        .values(items)
+        .on_conflict(uid)
+        .do_update()
+        .set((
+            object_name.eq(excluded(object_name)),
+            owner.eq(excluded(owner)),
+            blob_commitment.eq(excluded(blob_commitment)),
+            encoding.eq(excluded(encoding)),
+            encryption.eq(excluded(encryption)),
+            slice_address.eq(excluded(slice_address)),
+            placement_group.eq(excluded(placement_group)),
+            created_at.eq(excluded(created_at)),
+            updated_at.eq(excluded(updated_at)),
+            expires_at.eq(excluded(expires_at)),
+            size.eq(excluded(size)),
+            num_chunksets.eq(excluded(num_chunksets)),
+            payment_amount.eq(excluded(payment_amount)),
+            is_persisted.eq(excluded(is_persisted)),
+            is_committed.eq(excluded(is_committed)),
+            is_deleted.eq(excluded(is_deleted)),
+            etag.eq(excluded(etag)),
+            deletion_reason.eq(excluded(deletion_reason)),
+            last_transaction_version.eq(excluded(last_transaction_version)),
+        ))
+        .filter(last_transaction_version.le(excluded(last_transaction_version)))
+}
+
+fn insert_pg_slots_query(
+    items: Vec<PlacementGroupSlot>,
+) -> impl QueryFragment<Pg> + QueryId + Send {
+    use schema::placement_group_slots::dsl::*;
+    diesel::insert_into(schema::placement_group_slots::table)
+        .values(items)
+        .on_conflict((placement_group, slot_index))
+        .do_update()
+        .set((
+            storage_provider.eq(excluded(storage_provider)),
+            status.eq(excluded(status)),
+            updated_at.eq(excluded(updated_at)),
+            last_transaction_version.eq(excluded(last_transaction_version)),
+        ))
+        .filter(last_transaction_version.le(excluded(last_transaction_version)))
+}
+
+fn insert_activities_query(items: Vec<BlobActivity>) -> impl QueryFragment<Pg> + QueryId + Send {
+    use schema::blob_activities::dsl::*;
+    diesel::insert_into(schema::blob_activities::table)
+        .values(items)
+        .on_conflict((transaction_hash, event_type, event_index))
+        .do_nothing()
+}

--- a/processor/src/processors/shelby_blobs/shelby_blobs_storer.rs
+++ b/processor/src/processors/shelby_blobs/shelby_blobs_storer.rs
@@ -18,7 +18,7 @@ use aptos_indexer_processor_sdk::{
 use async_trait::async_trait;
 use bigdecimal::BigDecimal;
 use diesel::{
-    ExpressionMethods,
+    ExpressionMethods, QueryableByName,
     pg::{Pg, upsert::excluded},
     query_builder::{QueryFragment, QueryId},
     query_dsl::methods::FilterDsl,
@@ -26,6 +26,16 @@ use diesel::{
 };
 use diesel_async::RunQueryDsl;
 use std::collections::HashMap;
+use tracing::warn;
+
+/// Bounds the array size of a single partial-update statement.
+const BLOB_UPDATE_CHUNK_SIZE: usize = 1000;
+
+#[derive(QueryableByName)]
+struct MissingUid {
+    #[diesel(sql_type = Numeric)]
+    uid: BigDecimal,
+}
 
 pub struct ShelbyBlobsStorer
 where
@@ -123,9 +133,22 @@ impl Processable for ShelbyBlobsStorer {
 }
 
 impl ShelbyBlobsStorer {
-    /// One guarded statement: `COALESCE` preserves unset columns, the version
-    /// guard keeps latest-version-wins.
+    /// Partial updates go through raw SQL because `COALESCE(new, existing)` per
+    /// column isn't expressible in diesel's DSL. Values are passed as arrays, so
+    /// the statement uses ten bind parameters regardless of batch size and can't
+    /// hit diesel's u16 limit; we still chunk to bound the size of any one
+    /// statement, mirroring what `execute_in_chunks` does for the insert paths.
     async fn apply_blob_updates(
+        &self,
+        updates: &[BlobUpdate],
+    ) -> Result<(), diesel::result::Error> {
+        for chunk in updates.chunks(BLOB_UPDATE_CHUNK_SIZE) {
+            self.apply_blob_update_chunk(chunk).await?;
+        }
+        Ok(())
+    }
+
+    async fn apply_blob_update_chunk(
         &self,
         updates: &[BlobUpdate],
     ) -> Result<(), diesel::result::Error> {
@@ -171,8 +194,8 @@ impl ShelbyBlobsStorer {
             diesel::result::Error::QueryBuilderError(format!("pool error: {e}").into())
         })?;
 
-        diesel::sql_query(SQL)
-            .bind::<Array<Numeric>, _>(uids)
+        let updated = diesel::sql_query(SQL)
+            .bind::<Array<Numeric>, _>(uids.clone())
             .bind::<Array<BigInt>, _>(ltvs)
             .bind::<Array<Nullable<Numeric>>, _>(updated_at)
             .bind::<Array<Nullable<Numeric>>, _>(expires_at)
@@ -184,6 +207,30 @@ impl ShelbyBlobsStorer {
             .bind::<Array<Nullable<Numeric>>, _>(is_deleted)
             .execute(&mut conn)
             .await?;
+
+        // A short count is either the version guard rejecting a stale update
+        // (expected) or a blob whose registration fell outside the indexed
+        // range, which silently drops state. Only the latter is worth flagging.
+        if updated < updates.len() {
+            let missing: Vec<MissingUid> = diesel::sql_query(
+                "SELECT u AS uid FROM unnest($1) AS u \
+                 WHERE NOT EXISTS (SELECT 1 FROM blobs b WHERE b.uid = u)",
+            )
+            .bind::<Array<Numeric>, _>(uids)
+            .load(&mut conn)
+            .await?;
+
+            if !missing.is_empty() {
+                let sample: Vec<String> =
+                    missing.iter().take(10).map(|m| m.uid.to_string()).collect();
+                warn!(
+                    missing_count = missing.len(),
+                    sample = ?sample,
+                    "Dropped blob updates for uids with no registered row; the \
+                     BlobRegisteredEvent is likely before this run's starting version"
+                );
+            }
+        }
 
         Ok(())
     }
@@ -223,8 +270,13 @@ where
     by_key.into_values().collect()
 }
 
-/// Merges same-`uid` updates within a batch; later (higher-version) `Some` wins.
-fn merge_blob_updates(updates: Vec<BlobUpdate>) -> Vec<BlobUpdate> {
+/// Merges same-`uid` updates within a batch; the higher-version `Some` wins.
+fn merge_blob_updates(mut updates: Vec<BlobUpdate>) -> Vec<BlobUpdate> {
+    // Sorting first makes "last write wins" equal "highest version wins" without
+    // depending on the caller's ordering. The sort is stable, so events sharing a
+    // version keep their in-transaction order.
+    updates.sort_by_key(|u| u.last_transaction_version);
+
     let mut by_uid: HashMap<String, BlobUpdate> = HashMap::new();
     for u in updates {
         let key = u.uid.to_string();

--- a/processor/src/processors/shelby_blobs/tests.rs
+++ b/processor/src/processors/shelby_blobs/tests.rs
@@ -1,0 +1,370 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Storer tests against a real Postgres (SDK `PostgresTestDatabase`, needs Docker).
+//! Build `ShelbyBlobData` directly to exercise the upsert/guard logic.
+
+use crate::{
+    MIGRATIONS,
+    processors::shelby_blobs::{
+        models::{BlobActivity, BlobUpdate, NewBlob, PlacementGroupSlot, ShelbyBlobData},
+        shelby_blobs_storer::ShelbyBlobsStorer,
+    },
+};
+use ahash::AHashMap;
+use aptos_indexer_processor_sdk::{
+    postgres::utils::database::{ArcDbPool, new_db_pool, run_migrations},
+    testing_framework::database::{PostgresTestDatabase, TestDatabase},
+    traits::Processable,
+    types::transaction_context::{TransactionContext, TransactionMetadata},
+};
+use bigdecimal::BigDecimal;
+use diesel::{
+    QueryableByName,
+    sql_types::{BigInt, Nullable, Numeric, Text},
+};
+use diesel_async::RunQueryDsl;
+
+async fn setup() -> (PostgresTestDatabase, ArcDbPool) {
+    let mut db = PostgresTestDatabase::new();
+    db.setup().await.unwrap();
+    let url = db.get_db_url();
+    let pool = new_db_pool(&url, None).await.unwrap();
+    run_migrations(url, pool.clone(), MIGRATIONS).await;
+    (db, pool)
+}
+
+fn ctx(data: ShelbyBlobData, version: u64) -> TransactionContext<ShelbyBlobData> {
+    TransactionContext {
+        data,
+        metadata: TransactionMetadata {
+            start_version: version,
+            end_version: version,
+            start_transaction_timestamp: None,
+            end_transaction_timestamp: None,
+            total_size_in_bytes: 0,
+        },
+    }
+}
+
+fn bd(n: u64) -> BigDecimal {
+    BigDecimal::from(n)
+}
+
+/// A register event's full-snapshot row.
+fn reg(uid: u64, version: i64) -> NewBlob {
+    NewBlob {
+        uid: bd(uid),
+        object_name: format!("@a/{uid}"),
+        owner: "0x1".into(),
+        blob_commitment: "0xcommit".into(),
+        encoding: "ClayCode".into(),
+        encryption: "None".into(),
+        slice_address: "0x2".into(),
+        placement_group: "0x3".into(),
+        created_at: bd(100),
+        updated_at: bd(100),
+        expires_at: bd(999),
+        size: bd(64),
+        num_chunksets: bd(1),
+        payment_amount: bd(10),
+        is_persisted: bd(0),
+        is_committed: bd(0),
+        is_deleted: bd(0),
+        etag: None,
+        deletion_reason: None,
+        last_transaction_version: version,
+    }
+}
+
+fn activity(uid: u64, hash: &str, event_type: &str, version: i64) -> BlobActivity {
+    BlobActivity {
+        transaction_hash: hash.into(),
+        event_type: event_type.into(),
+        event_index: bd(0),
+        uid: bd(uid),
+        object_name: format!("@a/{uid}"),
+        owner: Some("0x1".into()),
+        transaction_version: bd(version as u64),
+        timestamp: chrono::DateTime::from_timestamp(0, 0).unwrap().naive_utc(),
+    }
+}
+
+#[derive(QueryableByName)]
+struct BlobState {
+    #[diesel(sql_type = Numeric)]
+    is_deleted: BigDecimal,
+    #[diesel(sql_type = Numeric)]
+    is_persisted: BigDecimal,
+    #[diesel(sql_type = Text)]
+    blob_commitment: String,
+    #[diesel(sql_type = Nullable<Text>)]
+    etag: Option<String>,
+    #[diesel(sql_type = BigInt)]
+    last_transaction_version: i64,
+}
+
+#[derive(QueryableByName)]
+struct Scalar {
+    #[diesel(sql_type = BigInt)]
+    n: i64,
+}
+
+#[derive(QueryableByName)]
+struct PgState {
+    #[diesel(sql_type = Text)]
+    status: String,
+    #[diesel(sql_type = BigInt)]
+    last_transaction_version: i64,
+}
+
+async fn blob_state(pool: &ArcDbPool, uid: u64) -> BlobState {
+    let mut conn = pool.get().await.unwrap();
+    diesel::sql_query(
+        "SELECT is_deleted, is_persisted, blob_commitment, etag, last_transaction_version \
+         FROM blobs WHERE uid = $1",
+    )
+    .bind::<Numeric, _>(bd(uid))
+    .get_result(&mut conn)
+    .await
+    .unwrap()
+}
+
+async fn count(pool: &ArcDbPool, table: &str) -> i64 {
+    let mut conn = pool.get().await.unwrap();
+    diesel::sql_query(format!("SELECT count(*) AS n FROM {table}"))
+        .get_result::<Scalar>(&mut conn)
+        .await
+        .unwrap()
+        .n
+}
+
+#[tokio::test]
+async fn blobs_lifecycle_and_undelete_guard() {
+    let (_db, pool) = setup().await;
+    let mut storer = ShelbyBlobsStorer::new(pool.clone(), AHashMap::new());
+
+    // Register @ v100.
+    storer
+        .process(ctx(
+            ShelbyBlobData {
+                new_blobs: vec![reg(1, 100)],
+                activities: vec![activity(1, "0xh1", "BlobRegisteredEvent", 100)],
+                ..Default::default()
+            },
+            100,
+        ))
+        .await
+        .unwrap();
+    let s = blob_state(&pool, 1).await;
+    assert_eq!(s.is_deleted, bd(0));
+    assert_eq!(s.last_transaction_version, 100);
+    assert_eq!(count(&pool, "blobs").await, 1);
+    assert_eq!(count(&pool, "blob_activities").await, 1);
+
+    // Persist @ v150: partial update.
+    storer
+        .process(ctx(
+            ShelbyBlobData {
+                blob_updates: vec![BlobUpdate {
+                    is_persisted: Some(bd(1)),
+                    updated_at: Some(bd(150)),
+                    ..BlobUpdate {
+                        uid: bd(1),
+                        last_transaction_version: 150,
+                        ..Default::default()
+                    }
+                }],
+                ..Default::default()
+            },
+            150,
+        ))
+        .await
+        .unwrap();
+    let s = blob_state(&pool, 1).await;
+    assert_eq!(s.is_persisted, bd(1));
+    assert_eq!(
+        s.blob_commitment, "0xcommit",
+        "COALESCE must preserve unset column"
+    );
+    assert_eq!(s.last_transaction_version, 150);
+
+    // Delete @ v200.
+    storer
+        .process(ctx(
+            ShelbyBlobData {
+                blob_updates: vec![BlobUpdate {
+                    is_deleted: Some(bd(1)),
+                    ..BlobUpdate {
+                        uid: bd(1),
+                        last_transaction_version: 200,
+                        ..Default::default()
+                    }
+                }],
+                ..Default::default()
+            },
+            200,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(blob_state(&pool, 1).await.is_deleted, bd(1));
+
+    // Replayed old register @ v100; the guard must block it.
+    storer
+        .process(ctx(
+            ShelbyBlobData {
+                new_blobs: vec![reg(1, 100)],
+                ..Default::default()
+            },
+            100,
+        ))
+        .await
+        .unwrap();
+    let s = blob_state(&pool, 1).await;
+    assert_eq!(
+        s.is_deleted,
+        bd(1),
+        "replayed old register must not undelete"
+    );
+    assert_eq!(s.last_transaction_version, 200);
+
+    // A genuinely newer register @ v300 SHOULD undelete.
+    storer
+        .process(ctx(
+            ShelbyBlobData {
+                new_blobs: vec![reg(1, 300)],
+                ..Default::default()
+            },
+            300,
+        ))
+        .await
+        .unwrap();
+    let s = blob_state(&pool, 1).await;
+    assert_eq!(s.is_deleted, bd(0), "newer register must undelete");
+    assert_eq!(s.last_transaction_version, 300);
+}
+
+#[tokio::test]
+async fn placement_group_status_and_guard() {
+    let (_db, pool) = setup().await;
+    let mut storer = ShelbyBlobsStorer::new(pool.clone(), AHashMap::new());
+
+    let slot = |status: &str, updated_at: u64, version: i64| PlacementGroupSlot {
+        placement_group: "0xpg".into(),
+        slot_index: bd(7),
+        storage_provider: "0xsp".into(),
+        status: status.into(),
+        updated_at: bd(updated_at),
+        last_transaction_version: version,
+    };
+
+    // assigned @ v10 -> activated @ v20.
+    storer
+        .process(ctx(
+            ShelbyBlobData {
+                pg_slots: vec![slot("joining", 10, 10)],
+                ..Default::default()
+            },
+            10,
+        ))
+        .await
+        .unwrap();
+    storer
+        .process(ctx(
+            ShelbyBlobData {
+                pg_slots: vec![slot("active", 20, 20)],
+                ..Default::default()
+            },
+            20,
+        ))
+        .await
+        .unwrap();
+    let mut conn = pool.get().await.unwrap();
+    let s: PgState = diesel::sql_query(
+        "SELECT status, last_transaction_version FROM placement_group_slots \
+         WHERE placement_group = '0xpg' AND slot_index = 7",
+    )
+    .get_result(&mut conn)
+    .await
+    .unwrap();
+    assert_eq!(s.status, "active");
+    assert_eq!(s.last_transaction_version, 20);
+
+    // Stale "joining" @ v15 must not overwrite the newer "active".
+    storer
+        .process(ctx(
+            ShelbyBlobData {
+                pg_slots: vec![slot("joining", 15, 15)],
+                ..Default::default()
+            },
+            15,
+        ))
+        .await
+        .unwrap();
+    let s: PgState = diesel::sql_query(
+        "SELECT status, last_transaction_version FROM placement_group_slots \
+         WHERE placement_group = '0xpg' AND slot_index = 7",
+    )
+    .get_result(&mut conn)
+    .await
+    .unwrap();
+    assert_eq!(
+        s.status, "active",
+        "stale event must not overwrite newer state"
+    );
+    assert_eq!(s.last_transaction_version, 20);
+}
+
+#[tokio::test]
+async fn within_batch_dedup_and_merge() {
+    let (_db, pool) = setup().await;
+    let mut storer = ShelbyBlobsStorer::new(pool.clone(), AHashMap::new());
+
+    // Two registers for uid=1 in one batch; highest version wins, single row.
+    storer
+        .process(ctx(
+            ShelbyBlobData {
+                new_blobs: vec![reg(1, 100), reg(1, 120)],
+                ..Default::default()
+            },
+            120,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(count(&pool, "blobs").await, 1);
+    assert_eq!(blob_state(&pool, 1).await.last_transaction_version, 120);
+
+    // Persist + commit for uid=1 in one batch merge into one update.
+    storer
+        .process(ctx(
+            ShelbyBlobData {
+                blob_updates: vec![
+                    BlobUpdate {
+                        is_persisted: Some(bd(1)),
+                        ..BlobUpdate {
+                            uid: bd(1),
+                            last_transaction_version: 130,
+                            ..Default::default()
+                        }
+                    },
+                    BlobUpdate {
+                        is_committed: Some(bd(1)),
+                        etag: Some("0xetag".into()),
+                        ..BlobUpdate {
+                            uid: bd(1),
+                            last_transaction_version: 140,
+                            ..Default::default()
+                        }
+                    },
+                ],
+                ..Default::default()
+            },
+            140,
+        ))
+        .await
+        .unwrap();
+    let s = blob_state(&pool, 1).await;
+    assert_eq!(s.is_persisted, bd(1));
+    assert_eq!(s.etag.as_deref(), Some("0xetag"));
+    assert_eq!(s.last_transaction_version, 140);
+}

--- a/processor/src/processors/shelby_blobs/tests.rs
+++ b/processor/src/processors/shelby_blobs/tests.rs
@@ -81,11 +81,11 @@ fn activity(uid: u64, hash: &str, event_type: &str, version: i64) -> BlobActivit
     BlobActivity {
         transaction_hash: hash.into(),
         event_type: event_type.into(),
-        event_index: bd(0),
+        event_index: 0,
         uid: bd(uid),
         object_name: format!("@a/{uid}"),
         owner: Some("0x1".into()),
-        transaction_version: bd(version as u64),
+        transaction_version: version,
         timestamp: chrono::DateTime::from_timestamp(0, 0).unwrap().naive_utc(),
     }
 }
@@ -367,4 +367,37 @@ async fn within_batch_dedup_and_merge() {
     assert_eq!(s.is_persisted, bd(1));
     assert_eq!(s.etag.as_deref(), Some("0xetag"));
     assert_eq!(s.last_transaction_version, 140);
+
+    // Same column set twice in one batch, fed newest-first: the higher version
+    // must still win.
+    storer
+        .process(ctx(
+            ShelbyBlobData {
+                blob_updates: vec![
+                    BlobUpdate {
+                        etag: Some("0xnewer".into()),
+                        ..BlobUpdate {
+                            uid: bd(1),
+                            last_transaction_version: 160,
+                            ..Default::default()
+                        }
+                    },
+                    BlobUpdate {
+                        etag: Some("0xolder".into()),
+                        ..BlobUpdate {
+                            uid: bd(1),
+                            last_transaction_version: 150,
+                            ..Default::default()
+                        }
+                    },
+                ],
+                ..Default::default()
+            },
+            160,
+        ))
+        .await
+        .unwrap();
+    let s = blob_state(&pool, 1).await;
+    assert_eq!(s.etag.as_deref(), Some("0xnewer"));
+    assert_eq!(s.last_transaction_version, 160);
 }


### PR DESCRIPTION
Indexes Shelby blob and placement group events into three tables:

- `blobs` — current state, one row per blob
- `blob_activities` — append-only event log
- `placement_group_slots` — storage provider slot assignments

`blobs` is keyed by `uid` rather than `object_name`, since names are reusable — writing the same name twice gives you two blobs.

`BlobRegisteredEvent` is the only event carrying every NOT NULL column, so it's the one that creates rows. The rest (persisted, committed, deleted, expiration extended) apply partial updates through a single bulk statement that `COALESCE`s the columns they don't set. `ObjectCommitRejectedEvent` is activity-only. Slot events are full snapshots, so plain upserts; activities are `ON CONFLICT DO NOTHING`.

Every upsert is guarded on `last_transaction_version` so a lower version can't clobber a higher one. Backfills share these tables with the live processor, and a replayed register event would otherwise resurrect an already-deleted blob. Within a batch, rows are deduped by primary key and updates to the same blob are merged, since Postgres won't let one statement touch the same conflict target twice.

Indices cover owner/name lookup, active blob listing, activity feeds by owner and version, and slot status. The `(owner, object_name) WHERE is_committed = 1 AND is_deleted = 0` one is what resolves a name to its current blob — overwrites leave the old rows behind, so that predicate needs to live in the index instead of being a post-scan filter.

`deployer_address` is config-driven so the same processor runs against any network — see `example-config-shelby-blobs.yaml`.

Deserialization failures panic rather than skip: an event type we index that won't parse means the on-chain shape moved, and skipping would leave the tables quietly incomplete.

Tests in `tests.rs` run the storer against a real Postgres and cover the undelete race, stale slot events, and within-batch dedup/merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New indexer path with non-trivial upsert/version semantics and partial updates; incorrect guards or backfill ordering could leave wrong blob or slot state, though scope is isolated to the new processor and tables.
> 
> **Overview**
> Adds a new **`shelby_blobs_processor`** that indexes Shelby contract events from the transaction stream into Postgres, with **`deployer_address`** in config so the same binary can target different networks.
> 
> **Schema & wiring:** New migration creates **`blobs`** (current state by `uid`), **`blob_activities`** (append-only log), and **`placement_group_slots`**. Diesel schema and **`ProcessorConfig::ShelbyBlobsProcessor`** are registered alongside the standard stream → extract → store → version-track pipeline.
> 
> **Indexing behavior:** Events under configurable `blob_metadata` and `placement_group` modules are parsed into row creates (`BlobRegisteredEvent`), partial **`BlobUpdate`**s with bulk `COALESCE` SQL, slot upserts, and activities (`ON CONFLICT DO NOTHING`). Writes use **`last_transaction_version`** guards, in-batch dedup/merge, and ordering so registers land before updates; deserialization mismatches **panic** instead of skipping.
> 
> **Tests:** Postgres integration tests cover lifecycle/undelete on replay, stale slot guards, and batch dedup/merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fb05113a7d031d92e44a8ce9f62f2c8e7489f73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->