### PR TITLE
Drop blob expiration from the Shelby blobs processor

### DIFF
--- a/processor/src/db/migrations/2026-07-13-000000_shelby_blobs/up.sql
+++ b/processor/src/db/migrations/2026-07-13-000000_shelby_blobs/up.sql
@@ -13,7 +13,6 @@ CREATE TABLE blobs (
     placement_group          VARCHAR(66) NOT NULL,
     created_at               NUMERIC NOT NULL,
     updated_at               NUMERIC NOT NULL,
-    expires_at               NUMERIC NOT NULL,
     size                     NUMERIC NOT NULL,
     num_chunksets            NUMERIC NOT NULL,
     payment_amount           NUMERIC NOT NULL,

--- a/processor/src/db/schema.rs
+++ b/processor/src/db/schema.rs
@@ -122,7 +122,6 @@ diesel::table! {
         placement_group -> Varchar,
         created_at -> Numeric,
         updated_at -> Numeric,
-        expires_at -> Numeric,
         size -> Numeric,
         num_chunksets -> Numeric,
         payment_amount -> Numeric,

--- a/processor/src/processors/shelby_blobs/models/read.rs
+++ b/processor/src/processors/shelby_blobs/models/read.rs
@@ -27,8 +27,6 @@ pub(super) struct BlobRegisteredEvent {
     pub chunkset_count: u32,
     #[serde(deserialize_with = "deserialize_from_string")]
     pub creation_micros: u64,
-    #[serde(deserialize_with = "deserialize_from_string")]
-    pub expiration_micros: u64,
     pub slice_address: String,
     pub placement_group_address: String,
     pub encoding: MoveVariant,
@@ -72,17 +70,6 @@ pub(super) struct ObjectDeletedEvent {
     pub object_name: String,
     #[serde(deserialize_with = "deserialize_from_string")]
     pub deleted_at_micros: u64,
-}
-
-#[derive(Debug, Deserialize)]
-pub(super) struct BlobExpirationExtendedEvent {
-    #[serde(deserialize_with = "deserialize_from_string")]
-    pub uid: u64,
-    pub object_name: String,
-    #[serde(deserialize_with = "deserialize_from_string")]
-    pub new_expiration_micros: u64,
-    #[serde(deserialize_with = "deserialize_from_string")]
-    pub updated_at_micros: u64,
 }
 
 #[derive(Debug, Deserialize)]

--- a/processor/src/processors/shelby_blobs/models/write.rs
+++ b/processor/src/processors/shelby_blobs/models/write.rs
@@ -37,7 +37,6 @@ pub struct NewBlob {
     pub placement_group: String,
     pub created_at: BigDecimal,
     pub updated_at: BigDecimal,
-    pub expires_at: BigDecimal,
     pub size: BigDecimal,
     pub num_chunksets: BigDecimal,
     pub payment_amount: BigDecimal,
@@ -79,7 +78,6 @@ pub struct BlobUpdate {
     pub uid: BigDecimal,
     pub last_transaction_version: i64,
     pub updated_at: Option<BigDecimal>,
-    pub expires_at: Option<BigDecimal>,
     pub owner: Option<String>,
     pub etag: Option<String>,
     pub deletion_reason: Option<String>,
@@ -180,7 +178,6 @@ impl ShelbyBlobData {
                     placement_group: standardize_address(&e.placement_group_address),
                     created_at: BigDecimal::from(e.creation_micros),
                     updated_at: BigDecimal::from(e.creation_micros),
-                    expires_at: BigDecimal::from(e.expiration_micros),
                     size: BigDecimal::from(e.blob_size),
                     num_chunksets: BigDecimal::from(e.chunkset_count),
                     payment_amount: BigDecimal::from(e.payment_amount),
@@ -236,17 +233,6 @@ impl ShelbyBlobData {
                     uid: BigDecimal::from(e.uid),
                     last_transaction_version: txn_version,
                     updated_at: Some(BigDecimal::from(e.deleted_at_micros)),
-                    ..Default::default()
-                });
-                (e.uid, e.object_name, None)
-            },
-            "BlobExpirationExtendedEvent" => {
-                let e = deser::<BlobExpirationExtendedEvent>(short, &event.data);
-                self.blob_updates.push(BlobUpdate {
-                    uid: BigDecimal::from(e.uid),
-                    last_transaction_version: txn_version,
-                    updated_at: Some(BigDecimal::from(e.updated_at_micros)),
-                    expires_at: Some(BigDecimal::from(e.new_expiration_micros)),
                     ..Default::default()
                 });
                 (e.uid, e.object_name, None)

--- a/processor/src/processors/shelby_blobs/shelby_blobs_storer.rs
+++ b/processor/src/processors/shelby_blobs/shelby_blobs_storer.rs
@@ -135,7 +135,7 @@ impl Processable for ShelbyBlobsStorer {
 impl ShelbyBlobsStorer {
     /// Partial updates go through raw SQL because `COALESCE(new, existing)` per
     /// column isn't expressible in diesel's DSL. Values are passed as arrays, so
-    /// the statement uses ten bind parameters regardless of batch size and can't
+    /// the statement uses nine bind parameters regardless of batch size and can't
     /// hit diesel's u16 limit; we still chunk to bound the size of any one
     /// statement, mirroring what `execute_in_chunks` does for the insert paths.
     async fn apply_blob_updates(
@@ -160,8 +160,6 @@ impl ShelbyBlobsStorer {
         let ltvs: Vec<i64> = updates.iter().map(|u| u.last_transaction_version).collect();
         let updated_at: Vec<Option<BigDecimal>> =
             updates.iter().map(|u| u.updated_at.clone()).collect();
-        let expires_at: Vec<Option<BigDecimal>> =
-            updates.iter().map(|u| u.expires_at.clone()).collect();
         let owner: Vec<Option<String>> = updates.iter().map(|u| u.owner.clone()).collect();
         let etag: Vec<Option<String>> = updates.iter().map(|u| u.etag.clone()).collect();
         let deletion_reason: Vec<Option<String>> =
@@ -176,7 +174,6 @@ impl ShelbyBlobsStorer {
         const SQL: &str = "
             UPDATE blobs AS b SET
                 updated_at = COALESCE(v.updated_at, b.updated_at),
-                expires_at = COALESCE(v.expires_at, b.expires_at),
                 owner = COALESCE(v.owner, b.owner),
                 etag = COALESCE(v.etag, b.etag),
                 deletion_reason = COALESCE(v.deletion_reason, b.deletion_reason),
@@ -184,8 +181,8 @@ impl ShelbyBlobsStorer {
                 is_committed = COALESCE(v.is_committed, b.is_committed),
                 is_deleted = COALESCE(v.is_deleted, b.is_deleted),
                 last_transaction_version = v.ltv
-            FROM unnest($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-                AS v(uid, ltv, updated_at, expires_at, owner, etag,
+            FROM unnest($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                AS v(uid, ltv, updated_at, owner, etag,
                       deletion_reason, is_persisted, is_committed, is_deleted)
             WHERE b.uid = v.uid AND b.last_transaction_version <= v.ltv
         ";
@@ -198,7 +195,6 @@ impl ShelbyBlobsStorer {
             .bind::<Array<Numeric>, _>(uids.clone())
             .bind::<Array<BigInt>, _>(ltvs)
             .bind::<Array<Nullable<Numeric>>, _>(updated_at)
-            .bind::<Array<Nullable<Numeric>>, _>(expires_at)
             .bind::<Array<Nullable<Text>>, _>(owner)
             .bind::<Array<Nullable<Text>>, _>(etag)
             .bind::<Array<Nullable<Text>>, _>(deletion_reason)
@@ -287,9 +283,6 @@ fn merge_blob_updates(mut updates: Vec<BlobUpdate>) -> Vec<BlobUpdate> {
                 if u.updated_at.is_some() {
                     m.updated_at = u.updated_at;
                 }
-                if u.expires_at.is_some() {
-                    m.expires_at = u.expires_at;
-                }
                 if u.owner.is_some() {
                     m.owner = u.owner;
                 }
@@ -333,7 +326,6 @@ fn insert_blobs_query(items: Vec<NewBlob>) -> impl QueryFragment<Pg> + QueryId +
             placement_group.eq(excluded(placement_group)),
             created_at.eq(excluded(created_at)),
             updated_at.eq(excluded(updated_at)),
-            expires_at.eq(excluded(expires_at)),
             size.eq(excluded(size)),
             num_chunksets.eq(excluded(num_chunksets)),
             payment_amount.eq(excluded(payment_amount)),

--- a/processor/src/processors/shelby_blobs/tests.rs
+++ b/processor/src/processors/shelby_blobs/tests.rs
@@ -64,7 +64,6 @@ fn reg(uid: u64, version: i64) -> NewBlob {
         placement_group: "0x3".into(),
         created_at: bd(100),
         updated_at: bd(100),
-        expires_at: bd(999),
         size: bd(64),
         num_chunksets: bd(1),
         payment_amount: bd(10),


### PR DESCRIPTION
The blob_metadata contract no longer has expirations: BlobRegisteredEvent lost expiration_micros and BlobExpirationExtendedEvent is gone entirely (shelby/shelby#1955). expiration_micros was a required field on the event struct and deser panics on a shape mismatch, so the processor would have crash-looped on the first blob registration against the upgraded contract.

The blobs.expires_at column goes with it. This processor has not run yet, so the original migration is edited in place rather than adding a follow-up that drops a column no deployment ever had.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Schema and event-parsing changes for the blobs indexer; low operational risk because the processor has not run yet, but a mismatch would crash indexing or drop expiration data.
> 
> **Overview**
> Aligns the Shelby blobs processor with the contract change that removed expirations (`BlobRegisteredEvent` no longer has `expiration_micros`; `BlobExpirationExtendedEvent` is gone). Required-field deser would have panic-looped on the first registration against the upgraded contract.
> 
> Removes `blobs.expires_at` from the original (unapplied) migration, Diesel schema, insert/upsert/partial-update paths, and tests. The expiration-extend event is no longer parsed or stored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2a5dd409685a5ffb09505a9a0165a3fb5726dde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->