### PR TITLE
Drop blobs.expires_at via its own migration

### DIFF
--- a/processor/src/db/migrations/2026-07-13-000000_shelby_blobs/up.sql
+++ b/processor/src/db/migrations/2026-07-13-000000_shelby_blobs/up.sql
@@ -13,6 +13,7 @@ CREATE TABLE blobs (
     placement_group          VARCHAR(66) NOT NULL,
     created_at               NUMERIC NOT NULL,
     updated_at               NUMERIC NOT NULL,
+    expires_at               NUMERIC NOT NULL,
     size                     NUMERIC NOT NULL,
     num_chunksets            NUMERIC NOT NULL,
     payment_amount           NUMERIC NOT NULL,

--- a/processor/src/db/migrations/2026-08-21-000000_drop_blob_expiration/down.sql
+++ b/processor/src/db/migrations/2026-08-21-000000_drop_blob_expiration/down.sql
@@ -1,0 +1,5 @@
+-- The original expiration timestamps are gone with the column, so existing rows are
+-- backfilled with zero. The default is then dropped to match the column as first created.
+
+ALTER TABLE blobs ADD COLUMN IF NOT EXISTS expires_at NUMERIC NOT NULL DEFAULT 0;
+ALTER TABLE blobs ALTER COLUMN expires_at DROP DEFAULT;

--- a/processor/src/db/migrations/2026-08-21-000000_drop_blob_expiration/up.sql
+++ b/processor/src/db/migrations/2026-08-21-000000_drop_blob_expiration/up.sql
@@ -1,0 +1,4 @@
+-- Blobs are stored until explicitly deleted, so registration no longer carries an
+-- expiration and the Shelby contract emits no expiry events.
+
+ALTER TABLE blobs DROP COLUMN IF EXISTS expires_at;


### PR DESCRIPTION
#189 removed the column by editing 2026-07-13-000000_shelby_blobs in place, but that migration had already been applied on shelby-beta and shelbynet-staging. Diesel tracks migrations by version and never re-runs an edited one, so those databases keep `expires_at NUMERIC NOT NULL` while the new NewBlob insert omits the column — every blob registration would fail the not-null constraint.

Restore the original migration and drop the column in a new one, so existing and freshly created databases converge on the same schema.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Schema change on the live `blobs` table; existing environments must run the new migration or inserts keep failing. Down migration cannot restore original expiry timestamps.
> 
> **Overview**
> Fixes blob registration on environments that already ran `2026-07-13-000000_shelby_blobs`. That migration had been edited in place to remove `expires_at`, but Diesel never re-runs applied versions, so those DBs still had a NOT NULL column while inserts omitted it.
> 
> Restores `expires_at` on the original create-table migration and adds `2026-08-21-000000_drop_blob_expiration` to drop the column. Fresh and already-migrated databases now converge on the same schema. The down migration re-adds the column with a temporary default of `0` (original expiry values cannot be recovered).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19f883ffc32834ca8dc8ce17f3fe49952ddd2840. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->