### PR TITLE
Shelby storer: transact removals, restore inserted_at, trim comments

### DIFF
--- a/processor/src/db/migrations/2026-09-01-000000_shelby_objects/up.sql
+++ b/processor/src/db/migrations/2026-09-01-000000_shelby_objects/up.sql
@@ -9,9 +9,9 @@
 -- clear.
 --
 -- `last_transaction_version` backs the latest-version-wins guard on every table
--- written more than once. There is no `inserted_at`: a wall-clock default would
--- stop this index being a deterministic function of the event stream, and so
--- rebuildable from the chain alone.
+-- written more than once. `inserted_at` carries a default and is never in an
+-- insert's values, so the chain-derived data stays a deterministic function of
+-- the event stream; only the wall clock differs, as on every other table here.
 
 DROP TABLE IF EXISTS blobs;
 DROP TABLE IF EXISTS blob_activities;
@@ -19,14 +19,8 @@ DROP TABLE IF EXISTS blob_activities;
 
 -- What a name resolves to, now. One row per live object, updated in place on
 -- overwrite and removed on delete, so it stays proportional to what exists.
---
 -- Written by ObjectCommittedEvent (upsert on `name`) and ObjectDeletedEvent
--- (delete, guarded on the stored version). A delete can drop the row rather
--- than tombstone it because the processor replays a contiguous range forward,
--- so a re-applied commit is always followed by the delete that came after it.
---
--- No lifecycle columns: `commit_object` asserts the blob is already durable, so
--- a row exists exactly when the name resolves to something readable.
+-- (delete, guarded on the stored version).
 CREATE TABLE shelby_objects (
     -- Object names are `@<owner>/<suffix>`, so a name is unique across accounts
     -- and one account's objects are a contiguous range of this key.
@@ -39,20 +33,17 @@ CREATE TABLE shelby_objects (
     -- is also what lets `name LIKE 'pfx%'` seek this column's indexes.
     name                     TEXT COLLATE "C" NOT NULL,
     owner                    VARCHAR(66) NOT NULL,
-    -- The etag S3 reports, `0x` and the hex of the event's bytes. The first
-    -- ETAG_LENGTH (16) bytes are a digest and anything after them is the suffix
-    -- in ASCII, so one rule renders either kind of object: hex the first
-    -- sixteen bytes, then append the rest. A single-blob etag has no rest; a
+    -- The etag S3 reports: hex the first ETAG_LENGTH (16) bytes (a digest),
+    -- then append the rest as ASCII. A single-blob etag has no rest; a
     -- multipart one carries `-<part count>`.
     etag                     TEXT NOT NULL,
-    -- How the object's bytes are encrypted, which a reader needs to interpret
-    -- them. Unconstrained on purpose: the indexer never reads it, so a scheme
-    -- added to the contract must not stop this processor.
+    -- How the object's bytes are encrypted. Unconstrained on purpose: the
+    -- indexer never reads it, so a scheme added to the contract must not stop
+    -- this processor.
     encryption               TEXT NOT NULL,
-    -- How the object's bytes are erasure coded. This fixes the size of a
-    -- chunkset, so it is what maps a plaintext range onto the stored bytes that
-    -- carry it, and a reader cannot size a range without it. Unconstrained for
-    -- the same reason as encryption.
+    -- How the object's bytes are erasure coded; fixes the chunkset size, which
+    -- maps a plaintext range onto stored bytes. Unconstrained for the same
+    -- reason as encryption.
     encoding                 TEXT NOT NULL,
     -- Region holding the object's bytes. One name for either kind of object: a
     -- single blob has its slice's region, and a multipart object's parts were all
@@ -61,12 +52,11 @@ CREATE TABLE shelby_objects (
     -- Bytes the object carries, encryption container excluded. The same
     -- measurement whichever variant below is populated.
     plaintext_size           BIGINT NOT NULL,
-    -- Bytes holding them, encryption container included: what reading the whole
-    -- object transfers, and what a payment for it is quantized against.
-    --
-    -- Stored rather than derived because a multipart object's containers are its
-    -- parts', one per part, so the overhead does not follow from the object's own
-    -- plaintext length. The chain sums it and reports it here.
+    -- Bytes holding the object's bytes, encryption container included: what
+    -- reading the whole object transfers, and what a payment for it is
+    -- quantized against. Stored rather than derived because a multipart
+    -- object's containers are its parts', one per part, so the overhead does
+    -- not follow from the object's own plaintext length.
     stored_size              BIGINT NOT NULL,
 
     -- ObjectContent::Blob -- the object resolves to one blob.
@@ -87,6 +77,7 @@ CREATE TABLE shelby_objects (
 
     committed_at_micros      BIGINT NOT NULL,
     last_transaction_version BIGINT NOT NULL,
+    inserted_at              TIMESTAMP NOT NULL DEFAULT NOW(),
 
     -- Resolves a name, orders a listing, carries its cursor, and bounds a
     -- prefix as `name >= 'pfx' AND name < 'pfx' || high-sentinel`.
@@ -101,68 +92,58 @@ CREATE TABLE shelby_objects (
     )
 );
 
--- One account's objects, ascending by name: every bucket listing. A name
--- embeds its owner, so these rows are also a contiguous range of the primary
--- key, but that is a convention of how names are built and not something the
--- planner can see.
+-- One account's objects, ascending by name: every bucket listing.
 CREATE INDEX shelby_objects_owner_name
     ON shelby_objects (owner, name);
 
--- Newest objects first, across every account: the explorer's feed, which has no
--- owner filter and so can use neither the index above nor the primary key.
+-- Newest objects first, across every account: the explorer's feed, which has
+-- no owner filter and so can use neither the index above nor the primary key.
 CREATE INDEX shelby_objects_committed_at
     ON shelby_objects (committed_at_micros DESC);
 
 
--- The uploads a client can still add parts to. An upload accumulates parts
--- under a name that does not resolve yet and may be abandoned rather than
--- committed, so its lifecycle is not an object's, and it has no shelby_objects
--- row to join to -- ListMultipartUploads is answered from this table alone.
+-- The uploads a client can still add parts to. ListMultipartUploads is
+-- answered from this table alone.
 --
 -- Written by MultipartUploadCreatedEvent, deleted by ObjectCommittedEvent when
--- its content is multipart, or by MultipartUploadAbortedEvent. Those are the
--- only ways a row leaves, and neither fires on its own: `abort_multipart_upload`
--- takes the client's signer and there is no expiry or admin sweep, so an
--- abandoned upload stays here for good. The table is bounded by uploads ever
--- started rather than by uploads in flight, which is why the listing below is
+-- its content is multipart, or by MultipartUploadAbortedEvent. There is no
+-- expiry or admin sweep, so an abandoned upload stays here for good; the table
+-- is bounded by uploads ever started, which is why the listing below is
 -- indexed rather than left to a scan.
 CREATE TABLE shelby_open_multipart_uploads (
     multipart_uid            BIGINT NOT NULL,
     -- The name this upload will claim if it completes. Not a foreign key: no
     -- object exists under it yet, and one may never exist. `COLLATE "C"` for
-    -- the reasons shelby_objects.name carries it -- ListMultipartUploads walks
-    -- the key space the same way, with a prefix and a delimiter.
+    -- the reasons shelby_objects.name carries it.
     object_name              TEXT COLLATE "C" NOT NULL,
     owner                    VARCHAR(66) NOT NULL,
     -- Scheme every part of this upload carries.
     encryption               TEXT NOT NULL,
     -- Coding every part of this upload carries.
     encoding                 TEXT NOT NULL,
-    -- Region every part of this upload is written to, resolved when it was opened.
-    -- A part takes it from the record, so the parts cannot disagree and the part
-    -- tables do not repeat it.
+    -- Region every part of this upload is written to, resolved when it was
+    -- opened. A part takes it from the record, so the parts cannot disagree
+    -- and the part tables do not repeat it.
     location_name            TEXT NOT NULL,
     created_at_micros        BIGINT NOT NULL,
     last_transaction_version BIGINT NOT NULL,
+    inserted_at              TIMESTAMP NOT NULL DEFAULT NOW(),
 
     -- Every multipart request arrives as an uploadId and resolves through this.
     PRIMARY KEY (multipart_uid)
 );
 
 -- ListMultipartUploads: one bucket's uploads, by key and then by upload id.
--- `owner` leads because a bucket is an account, `object_name` carries the
--- prefix and the `key-marker`, and `multipart_uid` is both the
--- `upload-id-marker` and S3's order within a key, a uid being a snowflake with
--- the millisecond in its high bits.
+-- `object_name` carries the prefix and the `key-marker`, and `multipart_uid`
+-- is both the `upload-id-marker` and S3's order within a key, a uid being a
+-- snowflake with the millisecond in its high bits.
 CREATE INDEX shelby_open_multipart_uploads_owner_name
     ON shelby_open_multipart_uploads (owner, object_name, multipart_uid);
 
 
--- What an open upload has accumulated so far: staging, not a manifest. It holds
--- everything uploaded, including parts a completion goes on to leave out, and
--- it dies with its upload. It inherits the growth described above, at up to
--- MAX_OBJECT_PARTS rows per abandoned upload; every query against it is keyed
--- by `multipart_uid`, so the cost is storage rather than latency.
+-- What an open upload has accumulated so far: staging, not a manifest. It
+-- holds everything uploaded, including parts a completion goes on to leave
+-- out, and it dies with its upload.
 --
 -- Written by PartCommittedEvent, where re-uploading a part number is an upsert
 -- on the same key. Deleted for the whole upload by ObjectCommittedEvent or
@@ -179,10 +160,11 @@ CREATE TABLE shelby_open_multipart_parts (
     stored_size              BIGINT NOT NULL,
     -- The bare digest, `0x` and thirty-two hex characters. A part's tag is
     -- pinned at ETAG_LENGTH by E_INVALID_PART_ETAG_LENGTH, so unlike an
-    -- object's it never carries a suffix, and ListParts quotes it as it stands.
+    -- object's it never carries a suffix.
     etag                     TEXT NOT NULL,
     committed_at_micros      BIGINT NOT NULL,
     last_transaction_version BIGINT NOT NULL,
+    inserted_at              TIMESTAMP NOT NULL DEFAULT NOW(),
 
     -- The ListParts query: the parts of one upload, ascending from a
     -- part-number marker. Also the bulk delete, on the leading column alone.
@@ -195,14 +177,10 @@ CREATE TABLE shelby_open_multipart_parts (
 --
 -- Its own table rather than a column on shelby_objects because a ranged read
 -- wants only the parts covering its range; held on the object row, every read
--- would fetch the whole manifest, which at the part ceiling is on the order of
--- 100 KB to serve an 8 MiB range.
+-- would fetch the whole manifest.
 --
 -- Promoted from shelby_open_multipart_parts at completion, restricted to the
 -- part numbers the commit event leaves unpruned, and never updated after.
--- Removing them is driven off the ObjectRef that ObjectDeletedEvent and an
--- overwriting ObjectCommittedEvent carry: an overwrite replaces the object row
--- in place and takes the old uid with it, so nothing here could be found again.
 CREATE TABLE shelby_object_parts (
     multipart_uid            BIGINT NOT NULL,
     part_number              INTEGER NOT NULL,
@@ -210,19 +188,18 @@ CREATE TABLE shelby_object_parts (
     blob_uid                 BIGINT NOT NULL,
 
     -- Where this part sits in the object: `[offset_in_object, end_offset)`.
-    -- Both bounds are stored and the size derived, rather than the other way
-    -- round, because a ranged read needs both to be indexed predicates. The
-    -- natural `offset < :end AND offset + plaintext_size > :start` puts an
-    -- expression on the second comparison, which no index serves and Hasura
-    -- cannot generate; storing the end makes it two plain column comparisons. A
-    -- part's plaintext size is `end_offset - offset_in_object`.
+    -- Both bounds are stored and the size derived, because a ranged read needs
+    -- both to be indexed predicates: `offset < :end AND offset +
+    -- plaintext_size > :start` puts an expression on the second comparison,
+    -- which no index serves. A part's plaintext size is `end_offset -
+    -- offset_in_object`.
     offset_in_object         BIGINT NOT NULL,
     end_offset               BIGINT NOT NULL,
 
-    -- Bytes reading this part transfers, container included. Carried across from
-    -- the staging row rather than derived from the span, so a part reports the
-    -- length its blob really has.
+    -- Bytes reading this part transfers, container included, carried across
+    -- from the staging row so a part reports the length its blob really has.
     stored_size              BIGINT NOT NULL,
+    inserted_at              TIMESTAMP NOT NULL DEFAULT NOW(),
 
     -- No `last_transaction_version`: a row is written once under a
     -- `multipart_uid` that is never reused, so no two writes ever contend.
@@ -244,28 +221,12 @@ CREATE INDEX shelby_object_parts_range
 -- Blobs registered but not yet committed: the candidate set for
 -- `garbage_collect_blobs`, which collects a pending blob once the contract's
 -- `PENDING_GC_GRACE_MICROS` window has elapsed since it was registered.
+-- Collection is permissionless, so anyone running this query can reclaim.
 --
--- A sweeper cannot find these anywhere else. The chain keys blobs by uid with no
--- way to enumerate them by state, and every other table here describes objects,
--- which is precisely what a pending blob is not yet. Collection is
--- permissionless, so anyone running this query can reclaim.
---
--- It also answers how much storage is committed to uploads that never finished,
--- which is what makes the backlog visible rather than merely collectable.
---
--- Written by BlobRegisteredEvent and deleted by the two events that end a blob's
--- wait: BlobPersistedEvent when it becomes durable, BlobDeletedEvent when it is
--- torn down. A blob leaves through exactly one of them, and the delete is keyed
--- on uid alone, so the teardown of a blob that was never here is a no-op.
---
--- Bounded by blobs currently in flight, unlike the staging tables above: every
--- row is claimed by one of those two events within a bounded window.
---
--- `BlobRegisteredEvent` does not say whether the blob was registered as an
--- object or as a part, so neither does this. Both kinds become collectable on
--- the same grace window, which is what this table exists to answer; a pending
--- part whose upload is already gone is collectable sooner, and that is the
--- contract's own check rather than something a query here anticipates.
+-- Written by BlobRegisteredEvent and deleted by the two events that end a
+-- blob's wait: BlobPersistedEvent when it becomes durable, BlobDeletedEvent
+-- when it is torn down. The delete is keyed on uid alone, so the teardown of
+-- a blob that was never here is a no-op.
 CREATE TABLE shelby_pending_blobs (
     uid                      BIGINT NOT NULL,
     owner                    VARCHAR(66) NOT NULL,
@@ -273,24 +234,25 @@ CREATE TABLE shelby_pending_blobs (
     location_name            TEXT NOT NULL,
     -- Registration time, which the grace window is measured from.
     creation_micros          BIGINT NOT NULL,
-    -- Bytes the blob was registered to hold, container included: what a sweep
-    -- reclaims by collecting it, and what an uncollected backlog is costing.
+    -- Bytes the blob was registered to hold, container included: what a
+    -- sweep reclaims by collecting it.
     stored_size              BIGINT NOT NULL,
     last_transaction_version BIGINT NOT NULL,
+    inserted_at              TIMESTAMP NOT NULL DEFAULT NOW(),
 
     -- A uid identifies a blob, and a sweep passes uids to the entry function.
     PRIMARY KEY (uid)
 );
 
 -- The sweep: the blobs registered longest ago, which are the ones whose grace
--- window has elapsed. Scanned forward from the oldest and stopped at the cutoff.
+-- window has elapsed.
 CREATE INDEX shelby_pending_blobs_creation
     ON shelby_pending_blobs (creation_micros);
 
 
 -- When each object appeared and went away: ObjectCommittedEvent and
--- ObjectDeletedEvent only, since opening an upload or adding a part to one is a
--- step toward an object rather than something that happened to one.
+-- ObjectDeletedEvent only, since opening an upload or adding a part to one is
+-- a step toward an object rather than something that happened to one.
 --
 -- The only unbounded table here, and the only one no other component reads, so
 -- a deployment with no explorer switches it off in the processor config and
@@ -309,16 +271,15 @@ CREATE TABLE shelby_object_activities (
     blob_uid                 BIGINT,
     multipart_uid            BIGINT,
     timestamp                TIMESTAMP NOT NULL,
+    inserted_at              TIMESTAMP NOT NULL DEFAULT NOW(),
 
-    -- Keyed on where the event sits in the chain rather than on its hash, as
-    -- every other activity table here is: reprocessing stays idempotent, the
-    -- index grows at its right edge, and read backwards the key is itself the
-    -- newest-first feed, stable across pages when one transaction emits several
-    -- events.
+    -- Keyed on where the event sits in the chain rather than on its hash:
+    -- reprocessing stays idempotent, and read backwards the key is itself the
+    -- newest-first feed, stable across pages when one transaction emits
+    -- several events.
     PRIMARY KEY (transaction_version, event_index)
 );
 
--- One account's history, newest first. The leading `owner` is what the primary
--- key cannot serve, since that orders by version across every account.
+-- One account's history, newest first.
 CREATE INDEX shelby_object_activities_owner_version
     ON shelby_object_activities (owner, transaction_version DESC, event_index DESC);

--- a/processor/src/db/schema.rs
+++ b/processor/src/db/schema.rs
@@ -104,6 +104,7 @@ diesel::table! {
         blob_uid -> Nullable<Int8>,
         multipart_uid -> Nullable<Int8>,
         timestamp -> Timestamp,
+        inserted_at -> Timestamp,
     }
 }
 
@@ -115,6 +116,7 @@ diesel::table! {
         offset_in_object -> Int8,
         end_offset -> Int8,
         stored_size -> Int8,
+        inserted_at -> Timestamp,
     }
 }
 
@@ -135,6 +137,7 @@ diesel::table! {
         kind -> Nullable<Text>,
         committed_at_micros -> Int8,
         last_transaction_version -> Int8,
+        inserted_at -> Timestamp,
     }
 }
 
@@ -148,6 +151,7 @@ diesel::table! {
         etag -> Text,
         committed_at_micros -> Int8,
         last_transaction_version -> Int8,
+        inserted_at -> Timestamp,
     }
 }
 
@@ -160,6 +164,7 @@ diesel::table! {
         creation_micros -> Int8,
         stored_size -> Int8,
         last_transaction_version -> Int8,
+        inserted_at -> Timestamp,
     }
 }
 
@@ -174,6 +179,7 @@ diesel::table! {
         location_name -> Text,
         created_at_micros -> Int8,
         last_transaction_version -> Int8,
+        inserted_at -> Timestamp,
     }
 }
 

--- a/processor/src/processors/shelby_blobs/models/write.rs
+++ b/processor/src/processors/shelby_blobs/models/write.rs
@@ -14,9 +14,12 @@
 //! registration adds a blob to it, and durability or teardown takes it out.
 
 use super::read::*;
-use crate::schema::{
-    placement_group_slots, shelby_object_activities, shelby_objects, shelby_open_multipart_parts,
-    shelby_open_multipart_uploads, shelby_pending_blobs,
+use crate::{
+    schema::{
+        placement_group_slots, shelby_object_activities, shelby_objects,
+        shelby_open_multipart_parts, shelby_open_multipart_uploads, shelby_pending_blobs,
+    },
+    utils::counters::SHELBY_EVENTS_SKIPPED_TOTAL,
 };
 use aptos_indexer_processor_sdk::{
     aptos_indexer_transaction_stream::utils::time::parse_timestamp,
@@ -252,7 +255,12 @@ impl ShelbyBlobData {
             "ObjectCommittedEvent" => {
                 let event = deser_versioned_event::<ObjectCommittedEvent>(short, &event.data)?;
                 match event {
-                    ObjectCommittedEvent::V1 {} => None,
+                    ObjectCommittedEvent::V1 {} => {
+                        SHELBY_EVENTS_SKIPPED_TOTAL
+                            .with_label_values(&[short])
+                            .inc();
+                        None
+                    },
                     ObjectCommittedEvent::V2 {
                         object_name,
                         owner,
@@ -337,7 +345,12 @@ impl ShelbyBlobData {
                 }
             },
             "ObjectDeletedEvent" => match deser_versioned_event(short, &event.data)? {
-                ObjectDeletedEvent::V1 {} => None,
+                ObjectDeletedEvent::V1 {} => {
+                    SHELBY_EVENTS_SKIPPED_TOTAL
+                        .with_label_values(&[short])
+                        .inc();
+                    None
+                },
                 ObjectDeletedEvent::V2 {
                     object_name,
                     owner,
@@ -496,7 +509,12 @@ fn deser_versioned_event<'a, T: serde::Deserialize<'a>>(
 ) -> Option<T> {
     match serde_json::from_str::<T>(data) {
         Ok(event) => Some(event),
-        Err(_) if is_unversioned_legacy_event(event_type, data) => None,
+        Err(_) if is_unversioned_legacy_event(event_type, data) => {
+            SHELBY_EVENTS_SKIPPED_TOTAL
+                .with_label_values(&[event_type])
+                .inc();
+            None
+        },
         Err(error) => panic!(
             "Failed to deserialize shelby event '{event_type}' (contract schema mismatch?): \
              {error} — data: {data}"

--- a/processor/src/processors/shelby_blobs/shelby_blobs_storer.rs
+++ b/processor/src/processors/shelby_blobs/shelby_blobs_storer.rs
@@ -17,7 +17,9 @@ use crate::{
 use ahash::AHashMap;
 use anyhow::Result;
 use aptos_indexer_processor_sdk::{
-    postgres::utils::database::{ArcDbPool, execute_in_chunks, get_config_table_chunk_size},
+    postgres::utils::database::{
+        ArcDbPool, MyDbConnection, execute_in_chunks, get_config_table_chunk_size,
+    },
     traits::{AsyncStep, NamedStep, Processable, async_step::AsyncRunType},
     types::transaction_context::TransactionContext,
     utils::errors::ProcessorError,
@@ -30,11 +32,15 @@ use diesel::{
     query_dsl::methods::FilterDsl,
     sql_types::{Array, BigInt, Integer, Text},
 };
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncConnection, RunQueryDsl, scoped_futures::ScopedFutureExt};
 use std::{collections::HashMap, hash::Hash};
 
 /// Bounds the array a single hand-written statement binds.
-const ARRAY_CHUNK_SIZE: usize = 1000;
+const DEFAULT_ARRAY_CHUNK_SIZE: usize = 1000;
+
+/// The connection the raw-SQL statements run on, inside the batch's
+/// transaction.
+type DbConn = MyDbConnection;
 
 pub struct ShelbyBlobsStorer
 where
@@ -99,18 +105,7 @@ impl Processable for ShelbyBlobsStorer {
             (input.metadata.start_version, input.metadata.end_version);
 
         // Writes before removals, since a batch can hold both a part commit and
-        // the completion that consumes it. Beyond that the order carries three
-        // things a version guard cannot: staged parts must exist before the
-        // promotion reads them, the promotion must run before `retire_uploads`
-        // deletes those same rows, and orphan deletion must run after the
-        // promotion so a commit and the overwrite displacing it in one batch
-        // leave nothing behind. An out-of-order promotion writes an empty
-        // manifest and reports no error.
-        //
-        // These statements share no transaction, so a crash lands mid-batch.
-        // The replay absorbs it: the version tracker has not advanced, staging
-        // survives because retirement had not run, and the promotion repeats
-        // under ON CONFLICT DO NOTHING.
+        // the completion that consumes it.
         execute_in_chunks(
             self.conn_pool.clone(),
             insert_uploads_query,
@@ -147,24 +142,8 @@ impl Processable for ShelbyBlobsStorer {
         .await
         .map_err(|e| store_error(start_version, end_version, &e))?;
 
-        self.promote_manifests(&sealed_uploads)
-            .await
-            .map_err(|e| store_error(start_version, end_version, &e))?;
-
-        self.drop_orphaned_manifests(&orphaned_manifests)
-            .await
-            .map_err(|e| store_error(start_version, end_version, &e))?;
-
-        self.delete_objects(&object_deletions)
-            .await
-            .map_err(|e| store_error(start_version, end_version, &e))?;
-
-        self.retire_uploads(&retired_uploads)
-            .await
-            .map_err(|e| store_error(start_version, end_version, &e))?;
-
-        // A blob registered and committed inside one batch appears in both lists,
-        // so the insert has to land before the removal that cancels it.
+        // A blob registered and committed inside one batch appears in both
+        // lists, so the insert has to land before the removal that cancels it.
         execute_in_chunks(
             self.conn_pool.clone(),
             insert_pending_blobs_query,
@@ -177,9 +156,30 @@ impl Processable for ShelbyBlobsStorer {
         .await
         .map_err(|e| store_error(start_version, end_version, &e))?;
 
-        self.remove_pending_blobs(&pending_blob_removals)
-            .await
-            .map_err(|e| store_error(start_version, end_version, &e))?;
+        // The removals and the manifest promotion run in one transaction. The
+        // order among them carries what a version guard cannot: staged parts
+        // must exist before the promotion reads them, the promotion must run
+        // before `retire_uploads` deletes those same rows, and orphan deletion
+        // must run after the promotion so a commit and the overwrite displacing
+        // it in one batch leave nothing behind. An out-of-order promotion
+        // writes an empty manifest and reports no error.
+        let mut conn =
+            self.conn_pool.get().await.map_err(|e| {
+                store_error(start_version, end_version, &format!("pool error: {e}"))
+            })?;
+        conn.transaction(|tx| {
+            async move {
+                promote_manifests(tx, &sealed_uploads).await?;
+                drop_orphaned_manifests(tx, &orphaned_manifests).await?;
+                delete_objects(tx, &object_deletions).await?;
+                retire_uploads(tx, &retired_uploads).await?;
+                remove_pending_blobs(tx, &pending_blob_removals).await?;
+                Ok::<(), diesel::result::Error>(())
+            }
+            .scope_boxed()
+        })
+        .await
+        .map_err(|e| store_error(start_version, end_version, &e))?;
 
         execute_in_chunks(
             self.conn_pool.clone(),
@@ -212,53 +212,47 @@ impl Processable for ShelbyBlobsStorer {
     }
 }
 
-impl ShelbyBlobsStorer {
-    /// Remove the objects whose names stopped resolving.
-    ///
-    /// Raw SQL because the guard compares against the stored row rather than
-    /// the incoming value, which diesel's delete DSL cannot express. Values are
-    /// passed as arrays, so the statement uses two bind parameters regardless
-    /// of batch size; chunking bounds the size of any one statement.
-    async fn delete_objects(
-        &self,
-        deletions: &[ObjectDeletion],
-    ) -> Result<(), diesel::result::Error> {
-        const SQL: &str = "
-            DELETE FROM shelby_objects AS o
-            USING unnest($1, $2) AS v(name, ltv)
-            WHERE o.name = v.name AND o.last_transaction_version <= v.ltv
-        ";
+/// Remove the objects whose names stopped resolving.
+///
+/// Raw SQL because the guard compares against the stored row rather than the
+/// incoming value, which diesel's delete DSL cannot express. Values are passed
+/// as arrays, so the statement uses two bind parameters regardless of batch
+/// size; chunking bounds the size of any one statement.
+async fn delete_objects(
+    conn: &mut DbConn,
+    deletions: &[ObjectDeletion],
+) -> Result<(), diesel::result::Error> {
+    const SQL: &str = "
+        DELETE FROM shelby_objects AS o
+        USING unnest($1, $2) AS v(name, ltv)
+        WHERE o.name = v.name AND o.last_transaction_version <= v.ltv
+    ";
 
-        for chunk in deletions.chunks(ARRAY_CHUNK_SIZE) {
-            let names: Vec<String> = chunk.iter().map(|d| d.name.clone()).collect();
-            let ltvs: Vec<i64> = chunk.iter().map(|d| d.last_transaction_version).collect();
+    for chunk in deletions.chunks(DEFAULT_ARRAY_CHUNK_SIZE) {
+        let names: Vec<String> = chunk.iter().map(|d| d.name.clone()).collect();
+        let ltvs: Vec<i64> = chunk.iter().map(|d| d.last_transaction_version).collect();
 
-            let mut conn = self.conn_pool.get().await.map_err(|e| {
-                diesel::result::Error::QueryBuilderError(format!("pool error: {e}").into())
-            })?;
-            diesel::sql_query(SQL)
-                .bind::<Array<Text>, _>(names)
-                .bind::<Array<BigInt>, _>(ltvs)
-                .execute(&mut conn)
-                .await?;
-        }
-        Ok(())
+        diesel::sql_query(SQL)
+            .bind::<Array<Text>, _>(names)
+            .bind::<Array<BigInt>, _>(ltvs)
+            .execute(conn)
+            .await?;
     }
+    Ok(())
+}
 
-    /// Turn each sealed upload's staged parts into the object's manifest, at
-    /// offsets that are a running sum over the parts the completion kept.
-    ///
-    /// Raw SQL, and one insert-from-select rather than rows sent from here,
-    /// because the sizes it sums are already in the database. Chunking bounds
-    /// the uid array; a chunk's pruned pairs are bounded only by how much the
-    /// completions in it pruned, which is nothing at all in the ordinary case.
-    async fn promote_manifests(
-        &self,
-        sealed: &[SealedUpload],
-    ) -> Result<(), diesel::result::Error> {
-        // DISTINCT: a repeated uid in $1 would join each staged part twice and
-        // silently double every offset.
-        const SQL: &str = "
+/// Turn each sealed upload's staged parts into the object's manifest, at
+/// offsets that are a running sum over the parts the completion kept.
+///
+/// Raw SQL, and one insert-from-select rather than rows sent from here,
+/// because the sizes it sums are already in the database.
+async fn promote_manifests(
+    conn: &mut DbConn,
+    sealed: &[SealedUpload],
+) -> Result<(), diesel::result::Error> {
+    // DISTINCT: a repeated uid in $1 would join each staged part twice and
+    // silently double every offset.
+    const SQL: &str = "
             WITH completed AS (
                 SELECT DISTINCT unnest($1::BIGINT[]) AS multipart_uid
             ), pruned AS (
@@ -301,113 +295,100 @@ impl ShelbyBlobsStorer {
             ON CONFLICT (multipart_uid, part_number) DO NOTHING
         ";
 
-        for chunk in sealed.chunks(ARRAY_CHUNK_SIZE) {
-            let uids: Vec<i64> = chunk.iter().map(|s| s.multipart_uid).collect();
-            let (pruned_uids, pruned_numbers): (Vec<i64>, Vec<i32>) = chunk
-                .iter()
-                .flat_map(|s| s.pruned_part_numbers.iter().map(|n| (s.multipart_uid, *n)))
-                .unzip();
+    for chunk in sealed.chunks(DEFAULT_ARRAY_CHUNK_SIZE) {
+        let uids: Vec<i64> = chunk.iter().map(|s| s.multipart_uid).collect();
+        let (pruned_uids, pruned_numbers): (Vec<i64>, Vec<i32>) = chunk
+            .iter()
+            .flat_map(|s| s.pruned_part_numbers.iter().map(|n| (s.multipart_uid, *n)))
+            .unzip();
 
-            let mut conn = self.conn_pool.get().await.map_err(|e| {
-                diesel::result::Error::QueryBuilderError(format!("pool error: {e}").into())
-            })?;
-            diesel::sql_query(SQL)
-                .bind::<Array<BigInt>, _>(uids)
-                .bind::<Array<BigInt>, _>(pruned_uids)
-                .bind::<Array<Integer>, _>(pruned_numbers)
-                .execute(&mut conn)
+        diesel::sql_query(SQL)
+            .bind::<Array<BigInt>, _>(uids)
+            .bind::<Array<BigInt>, _>(pruned_uids)
+            .bind::<Array<Integer>, _>(pruned_numbers)
+            .execute(conn)
+            .await?;
+    }
+    Ok(())
+}
+
+/// Remove the manifests of multipart records nothing resolves to any more.
+///
+/// No version guard, unlike the other removals here: a multipart uid is never
+/// reused, so no later write can land under one already disposed of.
+async fn drop_orphaned_manifests(
+    conn: &mut DbConn,
+    multipart_uids: &[i64],
+) -> Result<(), diesel::result::Error> {
+    const SQL: &str = "DELETE FROM shelby_object_parts WHERE multipart_uid = ANY($1)";
+
+    for chunk in multipart_uids.chunks(DEFAULT_ARRAY_CHUNK_SIZE) {
+        diesel::sql_query(SQL)
+            .bind::<Array<BigInt>, _>(chunk.to_vec())
+            .execute(conn)
+            .await?;
+    }
+    Ok(())
+}
+
+/// Drop the rows of blobs that stopped waiting to be committed.
+///
+/// Raw SQL for the same reason as `delete_objects`: the guard compares against
+/// the stored row. A uid that was never pending matches nothing, which is the
+/// ordinary case for a committed blob's teardown.
+async fn remove_pending_blobs(
+    conn: &mut DbConn,
+    removals: &[PendingBlobRemoval],
+) -> Result<(), diesel::result::Error> {
+    const SQL: &str = "
+        DELETE FROM shelby_pending_blobs AS b
+        USING unnest($1, $2) AS v(uid, ltv)
+        WHERE b.uid = v.uid AND b.last_transaction_version <= v.ltv
+    ";
+
+    for chunk in removals.chunks(DEFAULT_ARRAY_CHUNK_SIZE) {
+        let uids: Vec<i64> = chunk.iter().map(|r| r.uid).collect();
+        let ltvs: Vec<i64> = chunk.iter().map(|r| r.last_transaction_version).collect();
+
+        diesel::sql_query(SQL)
+            .bind::<Array<BigInt>, _>(uids)
+            .bind::<Array<BigInt>, _>(ltvs)
+            .execute(conn)
+            .await?;
+    }
+    Ok(())
+}
+
+/// Drop the staging rows of uploads that completed or were abandoned, parts
+/// included.
+async fn retire_uploads(
+    conn: &mut DbConn,
+    retirements: &[UploadRetirement],
+) -> Result<(), diesel::result::Error> {
+    const DELETE_PARTS_SQL: &str = "
+        DELETE FROM shelby_open_multipart_parts AS p
+        USING unnest($1, $2) AS v(multipart_uid, ltv)
+        WHERE p.multipart_uid = v.multipart_uid AND p.last_transaction_version <= v.ltv
+    ";
+    const DELETE_UPLOADS_SQL: &str = "
+        DELETE FROM shelby_open_multipart_uploads AS u
+        USING unnest($1, $2) AS v(multipart_uid, ltv)
+        WHERE u.multipart_uid = v.multipart_uid AND u.last_transaction_version <= v.ltv
+    ";
+
+    for chunk in retirements.chunks(DEFAULT_ARRAY_CHUNK_SIZE) {
+        let uids: Vec<i64> = chunk.iter().map(|r| r.multipart_uid).collect();
+        let ltvs: Vec<i64> = chunk.iter().map(|r| r.last_transaction_version).collect();
+
+        for sql in [DELETE_PARTS_SQL, DELETE_UPLOADS_SQL] {
+            diesel::sql_query(sql)
+                .bind::<Array<BigInt>, _>(uids.clone())
+                .bind::<Array<BigInt>, _>(ltvs.clone())
+                .execute(conn)
                 .await?;
         }
-        Ok(())
     }
-
-    /// Remove the manifests of multipart records nothing resolves to any more.
-    ///
-    /// No version guard, unlike the other removals here: a multipart uid is
-    /// never reused, so no later write can land under one already disposed of.
-    async fn drop_orphaned_manifests(
-        &self,
-        multipart_uids: &[i64],
-    ) -> Result<(), diesel::result::Error> {
-        const SQL: &str = "DELETE FROM shelby_object_parts WHERE multipart_uid = ANY($1)";
-
-        for chunk in multipart_uids.chunks(ARRAY_CHUNK_SIZE) {
-            let mut conn = self.conn_pool.get().await.map_err(|e| {
-                diesel::result::Error::QueryBuilderError(format!("pool error: {e}").into())
-            })?;
-            diesel::sql_query(SQL)
-                .bind::<Array<BigInt>, _>(chunk.to_vec())
-                .execute(&mut conn)
-                .await?;
-        }
-        Ok(())
-    }
-
-    /// Drop the rows of blobs that stopped waiting to be committed.
-    ///
-    /// Raw SQL for the same reason as `delete_objects`: the guard compares
-    /// against the stored row. A uid that was never pending matches nothing,
-    /// which is the ordinary case for a committed blob's teardown.
-    async fn remove_pending_blobs(
-        &self,
-        removals: &[PendingBlobRemoval],
-    ) -> Result<(), diesel::result::Error> {
-        const SQL: &str = "
-            DELETE FROM shelby_pending_blobs AS b
-            USING unnest($1, $2) AS v(uid, ltv)
-            WHERE b.uid = v.uid AND b.last_transaction_version <= v.ltv
-        ";
-
-        for chunk in removals.chunks(ARRAY_CHUNK_SIZE) {
-            let uids: Vec<i64> = chunk.iter().map(|r| r.uid).collect();
-            let ltvs: Vec<i64> = chunk.iter().map(|r| r.last_transaction_version).collect();
-
-            let mut conn = self.conn_pool.get().await.map_err(|e| {
-                diesel::result::Error::QueryBuilderError(format!("pool error: {e}").into())
-            })?;
-            diesel::sql_query(SQL)
-                .bind::<Array<BigInt>, _>(uids)
-                .bind::<Array<BigInt>, _>(ltvs)
-                .execute(&mut conn)
-                .await?;
-        }
-        Ok(())
-    }
-
-    /// Drop the staging rows of uploads that completed or were abandoned, parts
-    /// included.
-    async fn retire_uploads(
-        &self,
-        retirements: &[UploadRetirement],
-    ) -> Result<(), diesel::result::Error> {
-        const DELETE_PARTS_SQL: &str = "
-            DELETE FROM shelby_open_multipart_parts AS p
-            USING unnest($1, $2) AS v(multipart_uid, ltv)
-            WHERE p.multipart_uid = v.multipart_uid AND p.last_transaction_version <= v.ltv
-        ";
-        const DELETE_UPLOADS_SQL: &str = "
-            DELETE FROM shelby_open_multipart_uploads AS u
-            USING unnest($1, $2) AS v(multipart_uid, ltv)
-            WHERE u.multipart_uid = v.multipart_uid AND u.last_transaction_version <= v.ltv
-        ";
-
-        for chunk in retirements.chunks(ARRAY_CHUNK_SIZE) {
-            let uids: Vec<i64> = chunk.iter().map(|r| r.multipart_uid).collect();
-            let ltvs: Vec<i64> = chunk.iter().map(|r| r.last_transaction_version).collect();
-
-            let mut conn = self.conn_pool.get().await.map_err(|e| {
-                diesel::result::Error::QueryBuilderError(format!("pool error: {e}").into())
-            })?;
-            for sql in [DELETE_PARTS_SQL, DELETE_UPLOADS_SQL] {
-                diesel::sql_query(sql)
-                    .bind::<Array<BigInt>, _>(uids.clone())
-                    .bind::<Array<BigInt>, _>(ltvs.clone())
-                    .execute(&mut conn)
-                    .await?;
-            }
-        }
-        Ok(())
-    }
+    Ok(())
 }
 
 impl NamedStep for ShelbyBlobsStorer {

--- a/processor/src/processors/shelby_blobs/tests.rs
+++ b/processor/src/processors/shelby_blobs/tests.rs
@@ -682,6 +682,59 @@ async fn count(pool: &ArcDbPool, table: &str) -> i64 {
 
 // ─── Storer tests ───────────────────────────────────────────────────────────
 
+/// Every Shelby table carries a defaulted `inserted_at`, which an insert must
+/// pick up without the model naming it.
+#[tokio::test]
+async fn inserted_at_is_populated_on_every_table() {
+    let (_db, pool) = setup().await;
+    let mut storer = ShelbyBlobsStorer::new(pool.clone(), AHashMap::new());
+
+    storer
+        .process(ctx(
+            ShelbyBlobData {
+                objects: vec![blob_object("@0x1/a.txt", "0xaaaa", 100)],
+                uploads: vec![upload(1, 100)],
+                parts: vec![part(1, 1, 100)],
+                sealed_uploads: vec![SealedUpload {
+                    multipart_uid: 1,
+                    pruned_part_numbers: vec![],
+                }],
+                pending_blobs: vec![PendingBlob {
+                    uid: 9,
+                    owner: "0x1".into(),
+                    location_name: "us-east".into(),
+                    creation_micros: 100,
+                    stored_size: 64,
+                    last_transaction_version: 100,
+                }],
+                activities: vec![activity("@0x1/a.txt", 100)],
+                ..Default::default()
+            },
+            100,
+        ))
+        .await
+        .unwrap();
+
+    for table in [
+        "shelby_objects",
+        "shelby_open_multipart_uploads",
+        "shelby_open_multipart_parts",
+        "shelby_object_parts",
+        "shelby_pending_blobs",
+        "shelby_object_activities",
+    ] {
+        let mut conn = pool.get().await.unwrap();
+        let nulls = diesel::sql_query(format!(
+            "SELECT count(*) AS n FROM {table} WHERE inserted_at IS NULL"
+        ))
+        .get_result::<Scalar>(&mut conn)
+        .await
+        .unwrap()
+        .n;
+        assert_eq!(nulls, 0, "{table}: inserted_at not populated");
+    }
+}
+
 #[tokio::test]
 async fn an_object_is_overwritten_in_place_and_removed_on_deletion() {
     let (_db, pool) = setup().await;

--- a/processor/src/utils/counters.rs
+++ b/processor/src/utils/counters.rs
@@ -143,6 +143,20 @@ pub static EVENT_SINK_DELIVERY_ERRORS_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| 
     .unwrap()
 });
 
+/// Shelby events skipped because they predate the current schema: either an
+/// unversioned legacy shape (replay starts indexing at the versioned-event
+/// boundary) or a retired enum variant. Non-zero is expected while replaying
+/// early history; a sustained rate at the chain head means the contract moved
+/// and this processor hasn't.
+pub static SHELBY_EVENTS_SKIPPED_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "indexer_shelby_events_skipped_total",
+        "Count of Shelby events skipped as legacy or retired shapes",
+        &["event_type"]
+    )
+    .unwrap()
+});
+
 /// Seconds between now() and the latest processed block timestamp.
 /// First-class paging signal — aggregate alerts should AND against
 /// this < threshold to avoid firing on stale data.


### PR DESCRIPTION
A few follow-ups to #191. The Shelby migration hasn't shipped in a release yet, so I edited it in place instead of adding a new one.

**Removals now run in a transaction.** The five raw-SQL statements (manifest promotion, object/upload/pending-blob deletes, orphan cleanup) used to each grab their own connection and run back to back. Their order matters — promotion has to read staged parts before retirement deletes them, and so on — and the old code relied on crash-replay to paper over a mid-batch failure. That works, but it's a fragile thing to have to reason about. Now they share one connection and one transaction, so the batch either lands or it doesn't. The chunked inserts still go through `execute_in_chunks` in parallel as before.

**`inserted_at` is back.** #191 dropped it to keep the tables a pure function of the event stream, but nothing ever wrote the column explicitly anyway — it's just `DEFAULT NOW()`. What we actually lost was the "when did the indexer write this row" signal, which is the useful one for debugging. Added to all six Shelby tables, plus a test that it populates.

**Skipped events get a counter.** Events the processor silently drops (unversioned legacy shapes, retired `V1` variants) now bump `indexer_shelby_events_skipped_total` labelled by event type. Non-zero is expected while replaying early history; a sustained rate at the chain head means the contract moved and this processor hasn't.

**Trimmed the migration comments.** The table essays were doing a lot of narration; kept the parts that explain non-obvious decisions (COLLATE "C", storing both offset bounds, the uid sign-bit thing) and cut the rest. SQL is unchanged apart from the new columns.

Left for later: a CHECK on `placement_group_slots.status`.
