### PR TITLE
Upgrade Docker base images from Debian 11 to Debian 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # Stage 1: Build the binary
 
-FROM rust:slim-bullseye as builder
+FROM rust:slim-bookworm as builder
 
 WORKDIR /app
 
@@ -24,19 +24,19 @@ ENV GIT_SHA ${GIT_SHA}
 
 # Stage 2: Create the final image
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 COPY --from=builder /usr/local/bin/processor /usr/local/bin
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && apt-get install --no-install-recommends -y \
-        libssl1.1 \
+        libssl3 \
         ca-certificates \
         net-tools \
         tcpdump \
         iproute2 \
-        netcat \
+        netcat-openbsd \
         libdw-dev \
         libpq-dev \
         curl


### PR DESCRIPTION
## Problem

Both Docker stages are pinned to Debian 11 (bullseye), whose LTS window has now closed. The `bullseye-security` `Release` file has expired, so `apt-get update` fails outright and the image can no longer be built:

```
E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease is expired
   (invalid since 19h 29min 9s)
```

This is blocking builds and deploys of the processor in staging/perf.

## Fix

Move both stages to bookworm (Debian 12). Two packages had to be renamed alongside it:

- `libssl1.1` → `libssl3` — bookworm ships OpenSSL 3 and has no `libssl1.1` at all.
- `netcat` → `netcat-openbsd` — the `netcat` virtual package was replaced by concrete providers. `netcat-openbsd` still supplies `/bin/nc` via `update-alternatives`, so anything shelling out to `nc` is unaffected.

Bookworm rather than trixie: it's the one-step upgrade with the smaller blast radius, and it's supported through 2028.

## Verification

Ran a full `docker build` of this Dockerfile locally:

- Builder stage resolves all packages on `rust:slim-bookworm`. Bonus: `protobuf-compiler` goes from libprotoc 3.12.4 to 3.21.12, clearing tonic-build's 3.15 floor.
- Runtime stage installs cleanly (`update-alternatives: using /bin/nc.openbsd to provide /bin/nc`).
- Build exits 0, producing a 276MB image.
- `docker run --entrypoint /usr/local/bin/processor <image> --help` prints usage, confirming the `libssl3`/`libpq5` links resolve at runtime and not just at build time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the full build/runtime stack and OpenSSL major version at link time; low application code change but deploy/build regression risk if runtime deps differ in staging.
> 
> **Overview**
> Unblocks **processor** image builds by moving both Docker stages off expired **Debian 11 (bullseye)** repos to **Debian 12 (bookworm)**.
> 
> The **builder** stage now uses `rust:slim-bookworm`; the **runtime** stage uses `debian:bookworm-slim`. Runtime apt deps are adjusted for bookworm: **`libssl1.1` → `libssl3`** (OpenSSL 3) and **`netcat` → `netcat-openbsd`** so `/bin/nc` behavior stays the same via alternatives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e0eb6efeda8fc355e0eaab5f0f6cb4bf6682952. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->