### PR TITLE
Bump aptos-indexer-processor-sdk v2.3.0 → v2.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 [[package]]
 name = "aptos-indexer-processor-sdk"
 version = "0.2.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?tag=aptos-indexer-processor-sdk-v2.3.0#d1c52f82b9f638195ff6917f1818c339e1f35ecb"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?tag=aptos-indexer-processor-sdk-v2.4.0#4cc29be92b3090bfac34cd79b24b8edfb95b1081"
 dependencies = [
  "ahash",
  "anyhow",
@@ -177,7 +177,7 @@ source = "git+https://github.com/aptos-labs/aptos-core.git?rev=5a42c96be3ac94ef8
 [[package]]
 name = "aptos-indexer-transaction-stream"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?tag=aptos-indexer-processor-sdk-v2.3.0#d1c52f82b9f638195ff6917f1818c339e1f35ecb"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?tag=aptos-indexer-processor-sdk-v2.4.0#4cc29be92b3090bfac34cd79b24b8edfb95b1081"
 dependencies = [
  "anyhow",
  "aptos-moving-average",
@@ -200,7 +200,7 @@ dependencies = [
 [[package]]
 name = "aptos-moving-average"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?tag=aptos-indexer-processor-sdk-v2.3.0#d1c52f82b9f638195ff6917f1818c339e1f35ecb"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?tag=aptos-indexer-processor-sdk-v2.4.0#4cc29be92b3090bfac34cd79b24b8edfb95b1081"
 dependencies = [
  "chrono",
 ]
@@ -2539,7 +2539,7 @@ dependencies = [
 [[package]]
 name = "instrumented-channel"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?tag=aptos-indexer-processor-sdk-v2.3.0#d1c52f82b9f638195ff6917f1818c339e1f35ecb"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?tag=aptos-indexer-processor-sdk-v2.4.0#4cc29be92b3090bfac34cd79b24b8edfb95b1081"
 dependencies = [
  "delegate",
  "derive_builder",
@@ -2640,15 +2640,6 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -3853,8 +3844,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -3887,7 +3878,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4593,7 +4584,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 [[package]]
 name = "sample"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?tag=aptos-indexer-processor-sdk-v2.3.0#d1c52f82b9f638195ff6917f1818c339e1f35ecb"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?tag=aptos-indexer-processor-sdk-v2.4.0#4cc29be92b3090bfac34cd79b24b8edfb95b1081"
 dependencies = [
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ anyhow = "1.0.102"
 # https://github.com/aptos-labs/aptos-indexer-processors/pull/325
 # Do NOT enable the testing_framework feature here, it is conditionally enabled as a dev dependency
 # in the integration-tests/Cargo.toml file.
-aptos-indexer-processor-sdk = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", tag = "aptos-indexer-processor-sdk-v2.3.0", features = [
+aptos-indexer-processor-sdk = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", tag = "aptos-indexer-processor-sdk-v2.4.0", features = [
     "postgres_partial",
 ] }
 aptos-indexer-test-transactions = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "5a42c96be3ac94ef85ab6e53b618390dd343852f" }

--- a/processor/src/parquet_processors/parquet_processor_status_saver.rs
+++ b/processor/src/parquet_processors/parquet_processor_status_saver.rs
@@ -406,6 +406,8 @@ mod tests {
                 additional_headers: AdditionalHeaders::default(),
                 transaction_filter: None,
                 backup_endpoints: vec![],
+                primary_failback_interval_secs:
+                    TransactionStreamConfig::default_primary_failback_interval(),
             },
             progress_health_config: None,
         }

--- a/processor/src/processors/processor_status_saver.rs
+++ b/processor/src/processors/processor_status_saver.rs
@@ -394,6 +394,8 @@ mod tests {
                 additional_headers: AdditionalHeaders::default(),
                 transaction_filter: None,
                 backup_endpoints: vec![],
+                primary_failback_interval_secs:
+                    TransactionStreamConfig::default_primary_failback_interval(),
             },
             progress_health_config: None,
         }


### PR DESCRIPTION
Bumps the workspace pin of `aptos-indexer-processor-sdk` from tag `aptos-indexer-processor-sdk-v2.3.0` to `aptos-indexer-processor-sdk-v2.4.0`.

v2.4.0 adds proactive failback to the primary gRPC endpoint, which means `TransactionStreamConfig` gains a `primary_failback_interval_secs` field. Two exhaustive struct literals in test fixtures needed the new field filled in:

- `processor/src/processors/processor_status_saver.rs`
- `processor/src/parquet_processors/parquet_processor_status_saver.rs`

Both use `TransactionStreamConfig::default_primary_failback_interval()`, so behaviour is unchanged from the SDK default.

`cargo check --workspace` passes locally; leaving the rest to CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The SDK bump changes indexer gRPC stream behavior (primary failback) for all processors using the shared transaction stream config, though local test fixtures only explicitly set the new field.
> 
> **Overview**
> Upgrades the workspace dependency **`aptos-indexer-processor-sdk`** from **v2.3.0** to **v2.4.0** (`Cargo.toml` / `Cargo.lock`), pulling in SDK crates such as transaction stream and instrumented-channel at the new tag. The lockfile also reflects minor transitive shifts (e.g. dropped duplicate `itertools` 0.14, `prost-build`/`prost-derive` on older `itertools`/`heck`).
> 
> v2.4.0 adds **proactive failback to the primary gRPC endpoint**, so `TransactionStreamConfig` now includes **`primary_failback_interval_secs`**. This repo only updates **test helpers** that build full `TransactionStreamConfig` literals in `processor_status_saver.rs` and `parquet_processor_status_saver.rs`, setting the field via `TransactionStreamConfig::default_primary_failback_interval()` so tests match SDK defaults. Runtime paths that clone from loaded config are unchanged in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aae2f3e23886fc822bddbf32577fde10daf239a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->